### PR TITLE
Optimize left join with SQLDataService.GenerateSQL methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - ChangesToSqlBTMonitor now split queries by ';'.
 - Signatures of the method `GenerateQueriesForUpdateObjects` and its overloads.
 - Upgraded Npgsql version to 3.2.6.
+- Optimize left join with SQLDataService.GenerateSQL methods for some cases.
 
 ### Deprecated
 
@@ -28,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Appending view properties from not stored prop expression.
 - Updating empty array via `SQLDataService.UpdateObjects` (connections remain opened).
 - Updating array with no changes via `SQLDataService.UpdateObjects` (connections remain opened).
+- Incorrect altered state of masters after loading in some cases.
 
 ### Security
 

--- a/ICSSoft.STORMNET.DataObject/Information.cs
+++ b/ICSSoft.STORMNET.DataObject/Information.cs
@@ -1888,17 +1888,16 @@
                     prop.MultipleProp = true;
                 }
 
-                string spropname = curprop.Name;
                 string scurpropnamepart = string.Empty;
-                string scrupropnamepref = string.Empty;
-                string[] propname = spropname.Split('.');
-                string propalias = string.Empty;
+                string curpropName = curprop.Name.Replace("." + nameof(DataObject.__PrimaryKey), string.Empty);
+                string[] propname = curpropName.Split('.');
                 Type propType = null;
                 System.Type p = type;
                 Business.StorageStructForView.PropSource curSource = retVal.sources;
 
                 for (int j = 0; j < propname.Length; j++)
                 {
+                    string scrupropnamepref;
                     if (j == 0)
                     {
                         scurpropnamepart = propname[0];
@@ -1912,12 +1911,10 @@
 
                     if (j == propname.Length - 1)
                     {
-                        propalias = IsStoredProperty(p, propname[j]) ? GetPropertyStorageName(p, propname[j]) : null;
                         propType = GetPropertyType(p, propname[j]);
                     }
                     else
                     {
-                        string palias = GetPropertyStorageName(p, propname[j]);
                         bool propIsNotNull = GetPropertyNotNull(p, propname[j]);
 
                         bool found = false;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceGenerateSQLTests.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceGenerateSQLTests.cs
@@ -1,0 +1,120 @@
+﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests.Business
+{
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.Business;
+
+    using NewPlatform.Flexberry.ORM.Tests;
+
+    using Xunit;
+
+    public class SQLDataServiceGenerateSQLTests : BaseIntegratedTest
+    {
+        /// <summary>
+        /// Конструктор.
+        /// </summary>
+        public SQLDataServiceGenerateSQLTests()
+            : base("SQLDSG")
+        {
+        }
+
+        /// <summary>
+        /// Тест проверяет метод <see cref="SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct,bool)"/>,
+        /// чтобы в sql-запрос не добавляется left join, когда от мастера требуется только его первичный ключ.
+        /// </summary>
+        [Fact]
+        public void GenerateSQLSelectNoJoinsTest()
+        {
+            foreach (SQLDataService ds in DataServices)
+            {
+                // Arrange.
+                var view0 = new View { DefineClassType = typeof(Медведь) };
+                view0.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания));
+                var lcs0 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view0);
+
+                var view1 = new View { DefineClassType = typeof(Медведь) };
+                view1.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var lcs1 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view1);
+
+                var view2 = new View { DefineClassType = typeof(Медведь) };
+                view2.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var lcs2 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view2);
+
+                var view3 = new View { DefineClassType = typeof(Медведь) };
+                view3.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания));
+                var lcs3 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view3);
+
+                // Act.
+                string query0 = ds.GenerateSQLSelect(lcs0, false);
+                string query1 = ds.GenerateSQLSelect(lcs1, false);
+                string query2 = ds.GenerateSQLSelect(lcs2, false);
+                string query3 = ds.GenerateSQLSelect(lcs3, false);
+
+                // Assert.
+                ds.ExecuteNonQuery(query0);
+                ds.ExecuteNonQuery(query1);
+                ds.ExecuteNonQuery(query2);
+                ds.ExecuteNonQuery(query3);
+            }
+        }
+
+        /// <summary>
+        /// Тест проверяет метод <see cref="SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct,bool)"/>,
+        /// чтобы в sql-запрос добавляется только один необходимый left join.
+        /// </summary>
+        [Fact]
+        public void GenerateSQLSelectSingleJoinTest()
+        {
+            foreach (SQLDataService ds in DataServices)
+            {
+                // Arrange.
+                var view0 = new View { DefineClassType = typeof(Медведь) };
+                view0.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs0 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view0);
+
+                var view1 = new View { DefineClassType = typeof(Медведь) };
+                view1.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs1 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view1);
+
+                var view2 = new View { DefineClassType = typeof(Медведь) };
+                view2.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна.__PrimaryKey));
+                var lcs2 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view2);
+
+                var view3 = new View { DefineClassType = typeof(Медведь) };
+                view3.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна.__PrimaryKey),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs3 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view3);
+
+                // Act.
+                string query0 = ds.GenerateSQLSelect(lcs0, false);
+                string query1 = ds.GenerateSQLSelect(lcs1, false);
+                string query2 = ds.GenerateSQLSelect(lcs2, false);
+                string query3 = ds.GenerateSQLSelect(lcs3, false);
+
+                // Assert.
+                ds.ExecuteNonQuery(query0);
+                ds.ExecuteNonQuery(query1);
+                ds.ExecuteNonQuery(query2);
+                ds.ExecuteNonQuery(query3);
+            }
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="ICSSoft.STORMNET.Business\NotifyUpdateTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\MasterLoadingTests.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\SecondLoadObjectTest.cs" />
+    <Compile Include="ICSSoft.STORMNET.Business\SQLDataServiceGenerateSQLTests.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\SQLDataServiceTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\DataServiceSpeedTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\PrimaryKeyStorageTest.cs" />

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/BaseSQLDataServiceTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/BaseSQLDataServiceTests.cs
@@ -1,0 +1,26 @@
+﻿namespace NewPlatform.Flexberry.ORM.Tests
+{
+    using System.Collections.Generic;
+
+    using ICSSoft.STORMNET.Business;
+
+    public abstract class BaseSQLDataServiceTests
+    {
+        /// <summary>
+        /// The data services for temp databases (for <see cref="DataServices"/>).
+        /// </summary>
+        private readonly List<SQLDataService> _dataServices = new List<SQLDataService>();
+
+        /// <summary>
+        /// Data services for temp databases.
+        /// </summary>
+        protected IEnumerable<SQLDataService> DataServices => _dataServices;
+
+        protected BaseSQLDataServiceTests()
+        {
+            _dataServices.Add(new MSSQLDataService());
+            _dataServices.Add(new PostgresDataService());
+            _dataServices.Add(new OracleDataService());
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/SQLDataServiceGenerateSQLTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/SQLDataServiceGenerateSQLTests.cs
@@ -1,0 +1,184 @@
+﻿namespace NewPlatform.Flexberry.ORM.Tests
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.Business;
+
+    using Xunit;
+
+    public class SQLDataServiceGenerateSQLTests : BaseSQLDataServiceTests
+    {
+        /// <summary>
+        /// Тест проверяет метод <see cref="SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct,bool)"/>,
+        /// чтобы в sql-запрос не добавляется left join, когда от мастера требуется только его первичный ключ.
+        /// </summary>
+        [Fact]
+        public void GenerateSQLSelectNoJoinsTest()
+        {
+            foreach (SQLDataService ds in DataServices)
+            {
+                // Arrange.
+                var view0 = new View { DefineClassType = typeof(Медведь) };
+                view0.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания));
+                var lcs0 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view0);
+
+                var view1 = new View { DefineClassType = typeof(Медведь) };
+                view1.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var lcs1 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view1);
+
+                var view2 = new View { DefineClassType = typeof(Медведь) };
+                view2.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var lcs2 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view2);
+
+                var view3 = new View { DefineClassType = typeof(Медведь) };
+                view3.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания));
+                var lcs3 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view3);
+
+                // Act.
+                string query0 = ds.GenerateSQLSelect(lcs0, false);
+                string query1 = ds.GenerateSQLSelect(lcs1, false);
+                string query2 = ds.GenerateSQLSelect(lcs2, false);
+                string query3 = ds.GenerateSQLSelect(lcs3, false);
+                string from0 = query0.Substring(query0.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from1 = query1.Substring(query1.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from2 = query2.Substring(query2.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from3 = query3.Substring(query3.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+
+                // Assert.
+                Assert.DoesNotContain("join", from0, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Equal(from0, from1);
+                Assert.Equal(from0, from2);
+                Assert.Equal(from0, from3);
+            }
+        }
+
+        /// <summary>
+        /// Тест проверяет метод <see cref="SQLDataService.GenerateSQLSelectByStorageStruct(StorageStructForView,bool,bool,string,int,bool)"/>,
+        /// чтобы в sql-запрос не добавляется left join, когда от мастера требуется только его первичный ключ.
+        /// </summary>
+        [Fact]
+        public void GenerateSQLSelectByStorageStructNoJoinsTest()
+        {
+            foreach (SQLDataService ds in DataServices)
+            {
+                // Arrange.
+                var view0 = new View { DefineClassType = typeof(Медведь) };
+                view0.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания));
+                var storageStruct0 = Information.GetStorageStructForView(
+                    view0,
+                    view0.DefineClassType,
+                    StorageTypeEnum.SimpleStorage,
+                    ds.GetPropertiesInExpression,
+                    ds.GetType());
+
+                var view1 = new View { DefineClassType = typeof(Медведь) };
+                view1.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var storageStruct1 = Information.GetStorageStructForView(
+                    view1,
+                    view1.DefineClassType,
+                    StorageTypeEnum.SimpleStorage,
+                    ds.GetPropertiesInExpression,
+                    ds.GetType());
+
+                var view2 = new View { DefineClassType = typeof(Медведь) };
+                view2.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));
+                var storageStruct2 = Information.GetStorageStructForView(
+                    view2,
+                    view2.DefineClassType,
+                    StorageTypeEnum.SimpleStorage,
+                    ds.GetPropertiesInExpression,
+                    ds.GetType());
+
+                string advField = ds.GetConvertToTypeExpression(typeof(decimal), 0.ToString())
+                                  + " as "
+                                  + ds.PutIdentifierIntoBrackets("STORMNETDATAOBJECTTYPE");
+
+                // Act.
+                string query0 = ds.GenerateSQLSelectByStorageStruct(storageStruct0, true, true, advField, 0, false);
+                string query1 = ds.GenerateSQLSelectByStorageStruct(storageStruct1, true, true, advField, 0, false);
+                string query2 = ds.GenerateSQLSelectByStorageStruct(storageStruct2, true, true, advField, 0, false);
+                string from0 = query0.Substring(query0.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from1 = query1.Substring(query1.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from2 = query2.Substring(query2.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+
+                // Assert.
+                Assert.DoesNotContain("join", from0, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Equal(from0, from1);
+                Assert.Equal(from0, from2);
+            }
+        }
+
+        /// <summary>
+        /// Тест проверяет метод <see cref="SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct,bool)"/>,
+        /// чтобы в sql-запрос добавляется только один необходимый left join.
+        /// </summary>
+        [Fact]
+        public void GenerateSQLSelectSingleJoinTest()
+        {
+            foreach (SQLDataService ds in DataServices)
+            {
+                // Arrange.
+                var view0 = new View { DefineClassType = typeof(Медведь) };
+                view0.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs0 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view0);
+
+                var view1 = new View { DefineClassType = typeof(Медведь) };
+                view1.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs1 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view1);
+
+                var view2 = new View { DefineClassType = typeof(Медведь) };
+                view2.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна.__PrimaryKey));
+                var lcs2 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view2);
+
+                var view3 = new View { DefineClassType = typeof(Медведь) };
+                view3.AddProperties(
+                    Information.ExtractPropertyPath<Медведь>(x => x.Вес),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна.__PrimaryKey),
+                    Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.Страна));
+                var lcs3 = LoadingCustomizationStruct.GetSimpleStruct(typeof(Медведь), view3);
+
+                // Act.
+                string query0 = ds.GenerateSQLSelect(lcs0, false);
+                string query1 = ds.GenerateSQLSelect(lcs1, false);
+                string query2 = ds.GenerateSQLSelect(lcs2, false);
+                string query3 = ds.GenerateSQLSelect(lcs3, false);
+                string from0 = query0.Substring(query0.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from1 = query1.Substring(query1.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from2 = query2.Substring(query2.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+                string from3 = query3.Substring(query3.LastIndexOf("FROM", StringComparison.InvariantCultureIgnoreCase));
+
+                // Assert.
+                Assert.Equal(1, new Regex("left join", RegexOptions.IgnoreCase).Matches(query0).Count);
+                Assert.Equal(from0, from1);
+                Assert.Equal(from0, from2);
+                Assert.Equal(from0, from3);
+            }
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
+++ b/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
@@ -107,12 +107,14 @@
     <Compile Include="ICSSoft.STORMNET.Business.Audit\AuditClassSettingsLoaderTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business.Audit\AuditServiceTest.IsTypeAuditable.cs" />
     <Compile Include="ICSSoft.STORMNET.Business.LINQProvider\TestLinqProvider.cs" />
+    <Compile Include="ICSSoft.STORMNET.Business\BaseSQLDataServiceTests.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\BusinessServerOrderTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\DataServiceProviderTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\EnrichViewWithPropertiesUsedInFunctionTest.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\Utils\FillRowSetToDataObjectTests.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\InterfaceTests.cs" />
     <Compile Include="ICSSoft.STORMNET.Business\Utils\ProcessingRowsetDataRefTests.cs" />
+    <Compile Include="ICSSoft.STORMNET.Business\SQLDataServiceGenerateSQLTests.cs" />
     <Compile Include="ICSSoft.STORMNET.DataObject\KeyGuidTest.cs" />
     <Compile Include="ICSSoft.STORMNET.DataObject\PKHelper\PKComparerTest.cs" />
     <Compile Include="ICSSoft.STORMNET.DataObject\PKHelper\PKHelperTest.cs" />

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>5.1.0-beta13</version>
+    <version>5.1.0-beta14</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -32,6 +32,7 @@
       1. ChangesToSqlBTMonitor now split queries by ';'.
       2. Signatures of the method `GenerateQueriesForUpdateObjects` and its overloads.
       3. Upgraded Npgsql version to 3.2.6.
+      4. Optimize left join with SQLDataService.GenerateSQL methods for some cases.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2020</copyright>
     <tags>Flexberry ORM</tags>


### PR DESCRIPTION
Для случая, когда в представление добавляется первичный ключ мастера, например:
`view1.AddProperty(Information.ExtractPropertyPath<Медведь>(x => x.ЛесОбитания.__PrimaryKey));`
Методы генерации в SQLDataService отрабатывают неоптимально, в выражении FROM добавляется ненужный LEFT JOIN (на примере MSSQL):
SELECT 
"Медведь0"."Вес" as "Вес",
"Медведь0"."ЛесОбитания" as "ЛесОбитания",
"МедведьЛесОбитания0"."primaryKey" as "ЛесОбитания.__PrimaryKey",
"Медведь0"."primaryKey" as "STORMMainObjectKey",
"МедведьЛесОбитания0"."primaryKey" as "STORMJoinedMasterKey0",
"Медведь0"."ЛесОбитания" as "STORMJoinedMasterKey1", Convert(decimal,0) as "STORMNETDATAOBJECTTYPE"
FROM 
("Медведь" "Медведь0" 
	 LEFT JOIN  "Лес" "МедведьЛесОбитания0"
	 ON "Медведь0"."ЛесОбитания" = "МедведьЛесОбитания0"."primaryKey")

Ниже приложены файлы с телами запросов, которые генерируются в тесте GenerateSQLSelectNoJoinsTest после оптимизации (MSSQL):
[v0.txt](https://github.com/Flexberry/NewPlatform.Flexberry.ORM/files/4263158/v0.txt)
[v1.txt](https://github.com/Flexberry/NewPlatform.Flexberry.ORM/files/4263159/v1.txt)
[v2.txt](https://github.com/Flexberry/NewPlatform.Flexberry.ORM/files/4263160/v2.txt)
[v3.txt](https://github.com/Flexberry/NewPlatform.Flexberry.ORM/files/4263161/v3.txt)
