### PR TITLE
Add support of postgres table suffix and prefix modifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `DbTransactionWrapper` class to wrap `IDbConnection` and `IDbTransaction`.
 - Interfaces `IConverterToQueryValueString` and `IConvertibleToQueryValueString` to control the conversion of objects to a query string.
 - Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
+- Support of postgres table suffix and prefix modifiers.
 
 ### Changed
 - ChangesToSqlBTMonitor now split queries by ';'.

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>5.1.0-beta15</version>
+    <version>5.1.0-beta16</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -17,6 +17,7 @@
       2. `DbTransactionWrapper` class to wrap `IDbConnection` and `IDbTransaction`.
       3. Interfaces `IConverterToQueryValueString` and `IConvertibleToQueryValueString` to control the conversion of objects to a query string.
       4. Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
+      5. Support of postgres table suffix and prefix modifiers.
 
       Fixed
       1. Parsing nullable guids with PKHelper.GetKeys method.


### PR DESCRIPTION
https://www.postgresql.org/docs/9.6/ddl-inherit.html
Postgres supports modifiers of querying tables: prefix `ONLY` and suffix `*`. Both are essential to properly implement a table inheritance.