### PR TITLE
Правка обновления объектов, если найден цикл в графе зависимостей

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updating array with no changes via `SQLDataService.UpdateObjects` (connections remain opened).
 - Incorrect altered state of masters after loading in some cases.
 - Setting LoadingState.Loaded to DataObject after loading.
+- Objects updating order if exists cycle in dependencies graph of them.
 
 ### Security
 

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -5372,14 +5372,14 @@
                 }
             }
 
-            if (alteredLastList.Count > 0)
-            {
-                GenerateUpdateQueries(alteredLastList, updateList, updateTables, tableOperations, updateLastQueries);
-            }
-
             if (alteredList.Count > 0)
             {
                 GenerateUpdateQueries(alteredList, updateList, updateTables, tableOperations, updateQueries);
+            }
+
+            if (alteredLastList.Count > 0)
+            {
+                GenerateUpdateQueries(alteredLastList, updateList, updateTables, tableOperations, updateLastQueries);
             }
 
             deleteTables.Clear();

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>5.1.0-beta16</version>
+    <version>5.1.0-beta17</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -29,6 +29,7 @@
       7. Updating array with no changes via `SQLDataService.UpdateObjects` (connections remain opened).
       8. Incorrect altered state of masters after loading in some cases.
       9. Setting LoadingState.Loaded to DataObject after loading.
+      10. Objects updating order if exists cycle in dependencies graph of them.
 
       Changed
       1. ChangesToSqlBTMonitor now split queries by ';'.


### PR DESCRIPTION
Объект, который должен обновляться последним, пытался обновиться первым (в коллекции updateTables был над нулевым индексом), после чего выполнялись не те запросы для не тех таблиц, из-за чего была полная каша.