### PR TITLE
Fixed auditing objects with Unaltered status and Deleted not presented in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
 - Support of postgres table suffix and prefix modifiers.
 - Differ table modifiers `from` and `join` expressions.
+- Property AuditService.IsLogInfoEnabled to disable audit log info.
 
 ### Changed
 - ChangesToSqlBTMonitor now split queries by ';'.
@@ -41,6 +42,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix loading __PrimaryKey property of NotStored master.
 - Fix InitDataCopy for already loaded details.
 - Removed usage of DataServiceProvider.DataService for ExternalLangDef.
+- Auditing objects with Unaltered status and Deleted not presented in database.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
 - Support of postgres table suffix and prefix modifiers.
 - Differ table modifiers `from` and `join` expressions.
-- Property AuditService.IsLogInfoEnabled to disable audit log info.
+- Property AuditService.DetailedLogEnabled to disable audit log info.
 
 ### Changed
 - ChangesToSqlBTMonitor now split queries by ';'.

--- a/ICSSoft.STORMNET.Business/Audit/AuditService.cs
+++ b/ICSSoft.STORMNET.Business/Audit/AuditService.cs
@@ -172,7 +172,7 @@
         /// Flag indicates that this service uses <see cref="LogService.LogInfo(object)" /> and <see cref="LogService.LogInfoFormat" /> to log audit operation information.
         /// Default is <see langword="true" />.
         /// </summary>
-        public bool IsLogInfoEnabled { get; set; } = true;
+        public bool DetailedLogEnabled { get; set; } = true;
 
         /// <summary>
         /// Элемент, реализующий логику аудита.
@@ -567,7 +567,7 @@
                     && _typeAuditSettingsLoader.IsAuditEnabled(dataObjectType, typeOfAudit))
                 {
                     // Настройки вообще есть и аудит для приложения и для класса включён.
-                    if (IsLogInfoEnabled)
+                    if (DetailedLogEnabled)
                     {
                         LogService.LogInfoFormat(
                             "AuditService, WriteCommonAuditOperation: На аудит получен объект {2}:{0} со статусом {1}",
@@ -710,7 +710,7 @@
 
             commonAuditParameters.WriteMode = currentWriteMode;
 
-            if (IsLogInfoEnabled)
+            if (DetailedLogEnabled)
             {
                 LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0}:{1} отправляется {2}",
@@ -763,7 +763,7 @@
         {
             var currentWriteMode = checkedCustomAuditParameters.WriteMode;
 
-            if (IsLogInfoEnabled)
+            if (DetailedLogEnabled)
             {
                 LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0}:{1} отправляется {2}",
@@ -810,7 +810,7 @@
         /// <param name="checkClassAuditSettings">Следует ли проверять настройки аудита в классах.</param>
         protected virtual void CheckAndSendToAudit(RatificationAuditParameters ratificationAuditParameters, bool checkClassAuditSettings)
         {
-            if (IsLogInfoEnabled)
+            if (DetailedLogEnabled)
             {
                 LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0} отправляется {1} со статусом {2}",

--- a/ICSSoft.STORMNET.Business/Audit/AuditService.cs
+++ b/ICSSoft.STORMNET.Business/Audit/AuditService.cs
@@ -169,6 +169,12 @@
         public bool PersistUtcDates { get; set; }
 
         /// <summary>
+        /// Flag indicates that this service uses <see cref="LogService.LogInfo(object)" /> and <see cref="LogService.LogInfoFormat" /> to log audit operation information.
+        /// Default is <see langword="true" />.
+        /// </summary>
+        public bool IsLogInfoEnabled { get; set; } = true;
+
+        /// <summary>
         /// Элемент, реализующий логику аудита.
         /// </summary>
         public IAudit Audit
@@ -504,12 +510,16 @@
                 if (commonAuditParameters != null)
                 {
                     var operatedObject = commonAuditParameters.OldVersionOperatedObject ?? commonAuditParameters.OperatedObject; // для UPDATE нужно взять старую версию.
-                    var auditOperationId = CheckAndSendToAudit(commonAuditParameters, dataObjectType);
-                    auditAdditionalInfo = AuditAdditionalInfo.CreateRecord(
-                        auditOperationId,
-                        operatedObject,
-                        ConvertTypeOfAudit(commonAuditParameters.TypeOfAuditOperation),
-                        commonAuditParameters.AuditView);
+                    if (operatedObject != null)
+                    {
+                        // При удалении OperatedObject может быть null, если не удалось найти объект данных в БД.
+                        var auditOperationId = CheckAndSendToAudit(commonAuditParameters, dataObjectType);
+                        auditAdditionalInfo = AuditAdditionalInfo.CreateRecord(
+                            auditOperationId,
+                            operatedObject,
+                            ConvertTypeOfAudit(commonAuditParameters.TypeOfAuditOperation),
+                            commonAuditParameters.AuditView);
+                    }
                 }
 
                 return auditAdditionalInfo;
@@ -551,12 +561,20 @@
                 Type dataObjectType = operationedObject.GetType();
                 var objectStatus = operationedObject.GetStatus(false);
                 var typeOfAudit = ConvertObjectStatus(objectStatus);
-                if (_typeAuditSettingsLoader.HasSettings(dataObjectType)
+                if (objectStatus != ObjectStatus.UnAltered
+                    && _typeAuditSettingsLoader.HasSettings(dataObjectType)
                     && _typeAuditSettingsLoader.IsAuditEnabled(dataObjectType)
                     && _typeAuditSettingsLoader.IsAuditEnabled(dataObjectType, typeOfAudit))
                 {
                     // Настройки вообще есть и аудит для приложения и для класса включён.
-                    LogService.LogInfoFormat("AuditService, WriteCommonAuditOperation: На аудит получен объект {2}:{0} со статусом {1}", operationedObject, objectStatus, operationedObject.__PrimaryKey);
+                    if (IsLogInfoEnabled)
+                    {
+                        LogService.LogInfoFormat(
+                            "AuditService, WriteCommonAuditOperation: На аудит получен объект {2}:{0} со статусом {1}",
+                            operationedObject,
+                            objectStatus,
+                            operationedObject.__PrimaryKey);
+                    }
 
                     // Пробуем вычитать имя строки соединения непосредственно из настроек класса. Если не получается, берём по старой схеме.
                     string classConnectionStringName = _typeAuditSettingsLoader.GetAuditConnectionString(dataObjectType);
@@ -692,11 +710,14 @@
 
             commonAuditParameters.WriteMode = currentWriteMode;
 
-            LogService.LogInfoFormat(
+            if (IsLogInfoEnabled)
+            {
+                LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0}:{1} отправляется {2}",
                     commonAuditParameters.OperatedObject.__PrimaryKey,
                     commonAuditParameters.OperatedObject,
                     currentWriteMode == tWriteMode.Synchronous ? "синхронно" : "асинхронно");
+            }
 
             Guid? auditOperationId = null;
             if (currentWriteMode == tWriteMode.Asynchronous)
@@ -742,11 +763,14 @@
         {
             var currentWriteMode = checkedCustomAuditParameters.WriteMode;
 
-            LogService.LogInfoFormat(
+            if (IsLogInfoEnabled)
+            {
+                LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0}:{1} отправляется {2}",
                     checkedCustomAuditParameters.AuditObjectPrimaryKey,
                     checkedCustomAuditParameters.AuditObjectTypeOrDescription,
                     currentWriteMode == tWriteMode.Synchronous ? "синхронно" : "асинхронно");
+            }
 
             Guid? auditOperationId = null;
             if (currentWriteMode == tWriteMode.Asynchronous)
@@ -786,11 +810,14 @@
         /// <param name="checkClassAuditSettings">Следует ли проверять настройки аудита в классах.</param>
         protected virtual void CheckAndSendToAudit(RatificationAuditParameters ratificationAuditParameters, bool checkClassAuditSettings)
         {
-            LogService.LogInfoFormat(
+            if (IsLogInfoEnabled)
+            {
+                LogService.LogInfoFormat(
                     "AuditService, CheckAndSendToAudit: {0} отправляется {1} со статусом {2}",
                     string.Join(", ", ratificationAuditParameters.AuditOperationInfoList.Select(x => x.ToString()).ToArray()),
                     AppSetting.DefaultWriteMode == tWriteMode.Synchronous ? "синхронно" : "асинхронно",
                     ratificationAuditParameters.ExecutionResult);
+            }
 
             if (AppSetting.DefaultWriteMode == tWriteMode.Asynchronous)
             {
@@ -1056,7 +1083,7 @@
             if (dataObjectWithAuditFields != null)
             {
                 // Добавляем поля, кто же изменил объект. //TODO: определить эту запись в правильное место.
-                operationedObject.AddLoadedProperties(new List<string> { "EditTime", "Editor" });
+                operationedObject.AddLoadedProperties(nameof(IDataObjectWithAuditFields.EditTime), nameof(IDataObjectWithAuditFields.Editor));
                 dataObjectWithAuditFields.EditTime = GetAuditOperationTime(operationedObject);
                 dataObjectWithAuditFields.Editor = GetCurrentUserInfo(ApplicationMode, true);
             }
@@ -1398,6 +1425,7 @@
 
         /// <summary>
         /// Вычитать из базы соответствующий объекту объект.
+        /// TODO: в большинстве ситуаций достаточно проверить, что объект уже загружен необходимыми свойствами (рекурсия по детейлам).
         /// </summary>
         /// <param name="operationedObject">Объект, чью копию будем вычитывать из БД.</param>
         /// <param name="curView">Представление, по которому будем вычитывать из БД.</param>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>5.1.0-beta24</version>
+    <version>5.1.0-beta25</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -19,6 +19,7 @@
       4. Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
       5. Support of postgres table suffix and prefix modifiers.
       6. Differ table modifiers `from` and `join` expressions.
+      7. Property AuditService.IsLogInfoEnabled to disable audit log info.
 
       Fixed
       1. Parsing nullable guids with PKHelper.GetKeys method.
@@ -37,6 +38,7 @@
       14. Fix loading __PrimaryKey property of NotStored master.
       15. Fix InitDataCopy for already loaded details.
       16. Removed usage of DataServiceProvider.DataService for ExternalLangDef.
+      17. Auditing objects with Unaltered status and Deleted not presented in database.
 
       Changed
       1. ChangesToSqlBTMonitor now split queries by ';'.

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -19,7 +19,7 @@
       4. Interfaces `INotifyUpdateObjects`, `INotifyUpdateObject`, `INotifyUpdateProperty` and `INotifyUpdatePropertyByType` for notify when data is updates.
       5. Support of postgres table suffix and prefix modifiers.
       6. Differ table modifiers `from` and `join` expressions.
-      7. Property AuditService.IsLogInfoEnabled to disable audit log info.
+      7. Property AuditService.DetailedLogEnabled to disable audit log info.
 
       Fixed
       1. Parsing nullable guids with PKHelper.GetKeys method.


### PR DESCRIPTION
Added property AuditService.IsLogInfoEnabled to disable audit log info.