### PR TITLE
Add audit data services caching during write audit operations performing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
 - Parsing nullable guids with PKHelper.GetKeys method.
 - Getting property storage name when resolving circular dependencies.
 - Getting Unity container by replace UnityFactory.CreateContainer to UnityFactory.GetContainer.
@@ -44,7 +43,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed usage of DataServiceProvider.DataService for ExternalLangDef.
 - Auditing objects with Unaltered status and Deleted not presented in database.
 - Removed memory lock by business server (possible memory leakage).
-- Removed caching business server (fix multi-threading)
+- Removed caching business server (fix multi-threading).
+- Getting new instance of audit data service on every write audit operation.
 
 ### Security
 

--- a/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
+++ b/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
@@ -109,5 +109,13 @@
                 return dataService;
             }
         }
+
+        /// <summary>
+        /// Очистка кеша сервисов данных аудита.
+        /// </summary>
+        public static void ClearAuditDataServiceCache()
+        {
+            DataServiceCache.Clear();
+        }
     }
 }

--- a/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
+++ b/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
@@ -13,7 +13,6 @@
     /// </summary>
     public static class ConfigHelper
     {
-
         private static readonly Dictionary<string, IDataService> DataServiceCache =
             new Dictionary<string, IDataService>(StringComparer.InvariantCultureIgnoreCase);
 
@@ -100,8 +99,8 @@
                     .ToList();
 
                 IDataService dataService = foundConstructors.Count == 1
-                    ? (IDataService) foundConstructors[0].Invoke(new object[] {new EmptySecurityManager()})
-                    : (IDataService) Activator.CreateInstance(dataServiceRealType);
+                    ? (IDataService)foundConstructors[0].Invoke(new object[] { new EmptySecurityManager() })
+                    : (IDataService)Activator.CreateInstance(dataServiceRealType);
 
                 dataService.CustomizationString = realDataServiceCustomizationString;
                 DataServiceCache.Add(dataServiceCacheKey, dataService);

--- a/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
+++ b/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
@@ -71,9 +71,11 @@
             // Сначала пытаемся найти строку соединения с указанным именем.
             var dataServiceCustomizationString = GetConnectionString(currentAppMode, connStringName);
 
+            var dataServiceReturnedByDataServiceProvider = DataServiceProvider.DataService;
+
             Type dataServiceRealType =
                 string.IsNullOrEmpty(dataServiceType)
-                    ? DataServiceProvider.DataService.GetType()
+                    ? dataServiceReturnedByDataServiceProvider.GetType()
                     : Type.GetType(dataServiceType);
 
             if (dataServiceRealType == null || !(dataServiceRealType.IsSubclassOf(typeof(SQLDataService)) || dataServiceRealType == typeof(SQLDataService)))
@@ -82,7 +84,7 @@
             }
 
             var realDataServiceCustomizationString = string.IsNullOrEmpty(dataServiceCustomizationString)
-                ? DataServiceProvider.DataService.CustomizationString
+                ? dataServiceReturnedByDataServiceProvider.CustomizationString
                 : dataServiceCustomizationString;
 
             var dataServiceCacheKey = $"{dataServiceRealType.FullName}_{realDataServiceCustomizationString}";


### PR DESCRIPTION
Fix creating new instances of audit data services on every write audit operation.
This issue also causes continuous cache cleaning for agent manager on getting current user for audit.