### PR TITLE
`ControlProviderAttribute(string)` constructor ignores type loading error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `ICSSoft.STORMNET.Business.ODBCDataService` assembly.
 
 ### Fixed
+- `ControlProviderAttribute(string)` constructor ignores type loading error.
 
 ### Security
 

--- a/ICSSoft.STORMNET.DataObject/ControlProviderAttribute.cs
+++ b/ICSSoft.STORMNET.DataObject/ControlProviderAttribute.cs
@@ -27,15 +27,7 @@
         /// <param name="typeName">Тип ControlProvider'а строкой.</param>
         public ControlProviderAttribute(string typeName)
         {
-            try
-            {
-                var type = Type.GetType(typeName, true);
-                ControlProviderType = type;
-            }
-            catch (Exception exception)
-            {
-                throw new TypeLoadException("Ошибка загрузки типа провайдера элемента управления.", exception);
-            }
+            ControlProviderType = Type.GetType(typeName, false, true);
         }
     }
 }

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>6.0.0-beta11</version>
+    <version>6.0.0-beta12</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>


### PR DESCRIPTION
Partial stack trace:
```
   at ICSSoft.STORMNET.Windows.Forms.Binders.ControlProviderAttribute..ctor(String typeName) in C:\Workspace\github\NewPlatform.Flexberry.ORM\ICSSoft.STORMNET.DataObject\ControlProviderAttribute.cs:line 37
   at System.Reflection.CustomAttribute._CreateCaObject(RuntimeModule pModule, RuntimeType type, IRuntimeMethodInfo pCtor, Byte** ppBlob, Byte* pEndBlob, Int32* pcNamedArgs)
   at System.Reflection.CustomAttribute.CreateCaObject(RuntimeModule module, RuntimeType type, IRuntimeMethodInfo ctor, IntPtr& blob, IntPtr blobEnd, Int32& namedArgs)
   at System.Reflection.CustomAttribute.AddCustomAttributes(ListBuilder`1& attributes, RuntimeModule decoratedModule, Int32 decoratedMetadataToken, RuntimeType attributeFilterType, Boolean mustBeInheritable, ListBuilder`1 derivedAttributes)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeType type, RuntimeType caType, Boolean inherit)
   at System.RuntimeType.GetCustomAttributes(Type attributeType, Boolean inherit)
   at System.Attribute.GetCustomAttributes(MemberInfo element, Boolean inherit)
   at System.Reflection.CustomAttributeExtensions.GetCustomAttributes(MemberInfo element)
   at Microsoft.AspNetCore.Mvc.ModelBinding.ModelAttributes.GetAttributesForProperty(Type containerType, PropertyInfo property, Type modelType)
```