### PR TITLE
Fix `CompatibilityTypeTest.Check` concurrent behaviour.

### DIFF
--- a/ICSSoft.STORMNET.FunctionalLanguage/FunctionLanguageDef/CompatibilityTypeTest.cs
+++ b/ICSSoft.STORMNET.FunctionalLanguage/FunctionLanguageDef/CompatibilityTypeTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Совместимость типов
@@ -29,15 +30,19 @@
     /// </summary>
     public static class CompatibilityTypeTest
     {
-        static private System.Collections.Specialized.StringCollection _checkedTypes;
-        static private System.Collections.SortedList _canConvertTo;
-        static private System.Collections.Specialized.StringCollection _knownTypes;
-        static private readonly ConcurrentDictionary<long, TypesCompatibilities> CacheCheck = new ConcurrentDictionary<long, TypesCompatibilities>();
-        private static readonly string _lockConst = "CONST";
+        private static readonly ConcurrentDictionary<long, TypesCompatibilities> CacheCheck = new ConcurrentDictionary<long, TypesCompatibilities>();
+
+        private static readonly object LockConst = new object();
+
+        private static List<string> _checkedTypes;
+
+        private static Dictionary<string, List<string>> _canConvertTo;
+
+        private static List<string> _knownTypes;
 
         private static bool _initialized;
 
-        static private void ThisIsKnownType(Type type)
+        private static void ThisIsKnownType(Type type)
         {
             string typeName = type.FullName;
 
@@ -47,7 +52,7 @@
             }
         }
 
-        static private void AddPredifinedConvertion(Type systemtype, Type[] from, Type[] to)
+        private static void AddPredifinedConvertion(Type systemtype, Type[] from, Type[] to)
         {
             if (!_checkedTypes.Contains(systemtype.FullName))
             {
@@ -56,13 +61,12 @@
 
             ThisIsKnownType(systemtype);
 
-            System.Collections.Specialized.StringCollection sl;
             if (!_canConvertTo.ContainsKey(systemtype.FullName))
             {
-                _canConvertTo.Add(systemtype.FullName, new System.Collections.Specialized.StringCollection());
+                _canConvertTo.Add(systemtype.FullName, new List<string>());
             }
 
-            sl = (System.Collections.Specialized.StringCollection)_canConvertTo[systemtype.FullName];
+            List<string> sl = _canConvertTo[systemtype.FullName];
 
             for (int i = 0; i < to.Length; i++)
             {
@@ -78,10 +82,10 @@
                 ThisIsKnownType(from[i]);
                 if (!_canConvertTo.ContainsKey(from[i].FullName))
                 {
-                    _canConvertTo.Add(from[i].FullName, new System.Collections.Specialized.StringCollection());
+                    _canConvertTo.Add(from[i].FullName, new List<string>());
                 }
 
-                sl = (System.Collections.Specialized.StringCollection)_canConvertTo[from[i].FullName];
+                sl = _canConvertTo[from[i].FullName];
 
                 if (!sl.Contains(systemtype.FullName))
                 {
@@ -90,7 +94,7 @@
             }
         }
 
-        static private void AddType(Type tp)
+        private static void AddType(Type tp)
         {
             _checkedTypes.Add(tp.FullName);
 
@@ -103,13 +107,12 @@
                 {
                     Type f = mi.GetParameters()[0].ParameterType;
                     Type t = mi.ReturnType;
-                    System.Collections.Specialized.StringCollection sl;
                     if (!_canConvertTo.ContainsKey(f.FullName))
                     {
-                        _canConvertTo.Add(f.FullName, new System.Collections.Specialized.StringCollection());
+                        _canConvertTo.Add(f.FullName, new List<string>());
                     }
 
-                    sl = (System.Collections.Specialized.StringCollection)_canConvertTo[f.FullName];
+                    List<string> sl = _canConvertTo[f.FullName];
                     if (!sl.Contains(t.FullName))
                     {
                         sl.Add(t.FullName);
@@ -124,24 +127,23 @@
         /// <param name="from"></param>
         /// <param name="to"></param>
         /// <returns></returns>
-        static private bool FoundTransform(string from, string to, System.Collections.Specialized.StringCollection stack = null)
+        private static bool FoundTransform(string from, string to, List<string> stack = null)
         {
-            stack ??= new System.Collections.Specialized.StringCollection();
+            stack ??= new List<string>();
 
             bool res = false;
 
             if (_canConvertTo.ContainsKey(from))
             {
-                System.Collections.Specialized.StringCollection sl = (System.Collections.Specialized.StringCollection)_canConvertTo[from];
+                List<string> sl = _canConvertTo[from];
                 if (sl.Contains(to))
                 {
                     res = true;
                 }
                 else
                 {
-                    for (int i = 0; i < sl.Count; i++)
+                    foreach (string k in sl)
                     {
-                        string k = sl[i];
                         if (!stack.Contains(k))
                         {
                             stack.Add(k);
@@ -165,7 +167,7 @@
         /// <param name="from"></param>
         /// <param name="to"></param>
         /// <returns></returns>
-        static public TypesCompatibilities Check(Type from, Type to)
+        public static TypesCompatibilities Check(Type from, Type to)
         {
             if (from == null)
             {
@@ -231,7 +233,7 @@
 
             if (_canConvertTo.ContainsKey(from.FullName))
             {
-                System.Collections.Specialized.StringCollection sl = (System.Collections.Specialized.StringCollection)_canConvertTo[from.FullName];
+                List<string> sl = _canConvertTo[from.FullName];
                 if (sl.Contains(to.FullName))
                 {
                     return TypesCompatibilities.Convertable;
@@ -260,366 +262,118 @@
             if (_initialized)
                 return;
 
-            lock (_lockConst)
+            lock (LockConst)
             {
                 if (_initialized)
                     return;
 
-                _checkedTypes = new System.Collections.Specialized.StringCollection();
-                _canConvertTo = new System.Collections.SortedList();
-                _knownTypes = new System.Collections.Specialized.StringCollection();
+                _checkedTypes = new List<string>();
+                _canConvertTo = new Dictionary<string, List<string>>();
+                _knownTypes = new List<string>();
 
                 // predefined implicit conversion
                 // bool
                 AddPredifinedConvertion(
-                    typeof (bool),
+                    typeof(bool),
                     new Type[] { },
-                    new[] { typeof (int) });
+                    new[] { typeof(int) });
 
                 // typeof(byte)
                 AddPredifinedConvertion(
-                    typeof (byte),
+                    typeof(byte),
                     new Type[] { },
                     new[]
-                        {
-                            typeof (short), typeof (ushort), typeof (int), typeof (uint), typeof (long),
-                            typeof (ulong),
-                            typeof (float), typeof (double), typeof (decimal)
-                        });
+                    {
+                        typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long),
+                        typeof(ulong),
+                        typeof(float), typeof(double), typeof(decimal)
+                    });
 
                 // typeof(sbyte)
                 AddPredifinedConvertion(
-                    typeof (sbyte),
+                    typeof(sbyte),
                     new Type[] { },
                     new[]
-                        {
-                            typeof (short), typeof (int), typeof (long), typeof (float), typeof (double),
-                            typeof (decimal)
-                        });
+                    {
+                        typeof(short), typeof(int), typeof(long), typeof(float), typeof(double),
+                        typeof(decimal)
+                    });
 
                 // typeof(char)
                 AddPredifinedConvertion(
-                    typeof (char),
+                    typeof(char),
                     new Type[] { },
                     new[]
-                        {
-                            typeof (ushort), typeof (int), typeof (uint), typeof (long), typeof (ulong),
-                            typeof (float),
-                            typeof (double), typeof (decimal)
-                        });
+                    {
+                        typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong),
+                        typeof(float),
+                        typeof(double), typeof(decimal)
+                    });
 
                 // typeof(int)
                 AddPredifinedConvertion(
-                    typeof (int),
-                    new[] { typeof (sbyte), typeof (byte), typeof (short), typeof (ushort), typeof (char) },
-                    new[] { typeof (long), typeof (float), typeof (double), typeof (decimal) });
+                    typeof(int),
+                    new[] { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(char) },
+                    new[] { typeof(long), typeof(float), typeof(double), typeof(decimal) });
 
                 // typeof(uint)
                 AddPredifinedConvertion(
-                    typeof (uint),
-                    new[] { typeof (byte), typeof (ushort), typeof (char) },
-                    new[] { typeof (long), typeof (ulong), typeof (float), typeof (double), typeof (decimal) });
+                    typeof(uint),
+                    new[] { typeof(byte), typeof(ushort), typeof(char) },
+                    new[] { typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) });
 
                 // typeof(long)
                 AddPredifinedConvertion(
-                    typeof (long),
+                    typeof(long),
                     new[]
-                        {
-                            typeof (sbyte), typeof (byte), typeof (short), typeof (ushort), typeof (int),
-                            typeof (uint),
-                            typeof (char)
-                        },
-                    new[] { typeof (float), typeof (double), typeof (decimal) });
+                    {
+                        typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int),
+                        typeof(uint),
+                        typeof(char)
+                    },
+                    new[] { typeof(float), typeof(double), typeof(decimal) });
 
                 // typeof(ulong)
                 AddPredifinedConvertion(
-                    typeof (ulong),
-                    new[] { typeof (byte), typeof (ushort), typeof (uint), typeof (char) },
-                    new[] { typeof (float), typeof (double), typeof (decimal) });
+                    typeof(ulong),
+                    new[] { typeof(byte), typeof(ushort), typeof(uint), typeof(char) },
+                    new[] { typeof(float), typeof(double), typeof(decimal) });
 
                 // typeof(short)
                 AddPredifinedConvertion(
-                    typeof (short),
+                    typeof(short),
                     new Type[] { },
-                    new[] { typeof (int), typeof (long), typeof (float), typeof (double), typeof (decimal) });
+                    new[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal) });
 
                 // typeof(ushort)
                 AddPredifinedConvertion(
-                    typeof (ushort),
-                    new[] { typeof (byte), typeof (char) },
+                    typeof(ushort),
+                    new[] { typeof(byte), typeof(char) },
                     new[]
-                        {
-                            typeof (int), typeof (uint), typeof (long), typeof (ulong), typeof (float),
-                            typeof (double),
-                            typeof (decimal)
-                        });
+                    {
+                        typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float),
+                        typeof(double),
+                        typeof(decimal)
+                    });
 
                 // typeof(string)
                 AddPredifinedConvertion(
-                    typeof (string),
+                    typeof(string),
                     new[]
-                        {
-                            typeof (int), typeof (uint), typeof (long), typeof (ulong), typeof (float),
-                            typeof (double), typeof (decimal)
-                        },
+                    {
+                        typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float),
+                        typeof(double), typeof(decimal)
+                    },
                     new Type[] { });
 
                 // typeof(Guid)
                 AddPredifinedConvertion(
-                    typeof (Guid),
+                    typeof(Guid),
                     new Type[] { },
-                    new[] { typeof (string) });
+                    new[] { typeof(string) });
 
                 _initialized = true;
             }
         }
     }
-
-    /*
-    public class CompatibilityTypeTest1
-    {
-        public CompatibilityTypeTest1()
-        { }
-
-        private System.Collections.Specialized.StringCollection CheckedTypes;
-        private System.Collections.SortedList CanConvertTo;
-        private System.Collections.Specialized.StringCollection KnownTypes;
-
-        private void ThisIsKnownType(System.Type type)
-        {
-            string TypeName = type.FullName;
-            if (!KnownTypes.Contains(TypeName))
-                KnownTypes.Add(TypeName);
-        }
-
-        private void AddPredifinedConvertion(System.Type systemtype, System.Type[] from, System.Type[] to)
-        {
-            if (!CheckedTypes.Contains(systemtype.FullName))
-                CheckedTypes.Add(systemtype.FullName);
-            ThisIsKnownType(systemtype);
-
-            System.Collections.Specialized.StringCollection sl;
-            if (CanConvertTo.ContainsKey(systemtype.FullName))
-                sl = (System.Collections.Specialized.StringCollection)CanConvertTo[systemtype.FullName];
-            else
-            {
-                sl = new System.Collections.Specialized.StringCollection();
-                CanConvertTo.Add(systemtype.FullName, sl);
-            }
-            for (int i = 0; i < to.Length; i++)
-            {
-                ThisIsKnownType(to[i]);
-                if (!sl.Contains(to[i].FullName))
-                    sl.Add(to[i].FullName);
-            }
-            for (int i = 0; i < from.Length; i++)
-            {
-                ThisIsKnownType(from[i]);
-                if (CanConvertTo.ContainsKey(from[i].FullName))
-                    sl = (System.Collections.Specialized.StringCollection)CanConvertTo[from[i].FullName];
-                else
-                {
-                    sl = new System.Collections.Specialized.StringCollection();
-                    CanConvertTo.Add(from[i].FullName, sl);
-                }
-                if (!sl.Contains(systemtype.FullName))
-                    sl.Add(systemtype.FullName);
-            }
-        }
-
-        private void AddType(System.Type tp)
-        {
-            CheckedTypes.Add(tp.FullName);
-            ThisIsKnownType(tp);
-
-            System.Reflection.MethodInfo[] mis = tp.GetMethods();
-            foreach (System.Reflection.MethodInfo mi in mis)
-            {
-                if (mi.IsSpecialName && (mi.Name == "op_Implicit" || mi.Name == "op_Explicit"))
-                {
-                    System.Type f = mi.GetParameters()[0].ParameterType;
-                    System.Type t = mi.ReturnType;
-                    System.Collections.Specialized.StringCollection sl;
-                    if (CanConvertTo.ContainsKey(f.FullName))
-                        sl = (System.Collections.Specialized.StringCollection)CanConvertTo[f.FullName];
-                    else
-                    {
-                        sl = new System.Collections.Specialized.StringCollection();
-                        CanConvertTo.Add(f.FullName, sl);
-                    }
-                    if (!sl.Contains(t.FullName))
-                        sl.Add(t.FullName);
-                }
-            };
-        }
-        System.Collections.Specialized.StringCollection stack;
-        private bool FoundTransform(string from, string to)
-        {
-            bool EmptyStack = stack == null;
-            if (EmptyStack)
-                stack = new System.Collections.Specialized.StringCollection();
-            bool res = false;
-
-            if (CanConvertTo.ContainsKey(from))
-            {
-                System.Collections.Specialized.StringCollection sl = (System.Collections.Specialized.StringCollection)CanConvertTo[from];
-                if (sl.Contains(to))
-                    res = true;
-                else
-                {
-                    for (int i = 0; i < sl.Count; i++)
-                    {
-                        string k = sl[i];
-                        if (!stack.Contains(k))
-                        {
-                            stack.Add(k);
-                            res = FoundTransform(k, to);
-                            stack.RemoveAt(stack.Count - 1);
-                            if (res) break;
-                        }
-                    }
-                }
-            }
-            else
-                res = false;
-
-            if (EmptyStack)
-                stack = null;
-            return res;
-        }
-
-        public TypesCompatibilities Check(System.Type from, System.Type to)
-        {
-            if (from == to)
-                return TypesCompatibilities.Equal;
-            if (from.IsSubclassOf(to))
-                return TypesCompatibilities.Convertable;
-            else if (from == typeof(object) || to == typeof(object))
-            {
-                return TypesCompatibilities.Convertable;
-            }
-            else
-            {
-                //стандартный Convert
-
-                //              System.Reflection.ConstructorInfo ci =from.GetConstructor(new System.Type[0]);
-                //              try
-                //              {
-                //                  object obj = ci.Invoke(new object[0]);
-                //                  if (obj!=null)
-                //                  {
-                //                      obj =  Convert.ChangeType(obj,to);
-                //                      return TypesCompatibilities.Convertable;
-                //                  }
-                //                  else if (!to.IsValueType)
-                //                      return TypesCompatibilities.Convertable;
-                //              }
-                //              catch
-                //              {}
-                //implicit преобразования
-                if (CheckedTypes == null)
-                {
-                    CheckedTypes = new System.Collections.Specialized.StringCollection();
-                    CanConvertTo = new System.Collections.SortedList();
-                    KnownTypes = new System.Collections.Specialized.StringCollection();
-                    //predefined implicit conversion
-                    //bool
-                    AddPredifinedConvertion(
-                        typeof(bool),
-                        new Type[] { },
-                        new Type[] { typeof(int) });
-                    //typeof(byte)
-                    AddPredifinedConvertion(
-                        typeof(byte),
-                        new Type[] { },
-                        new Type[] { typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(sbyte)
-                    AddPredifinedConvertion(
-                        typeof(sbyte),
-                        new Type[] { },
-                        new Type[] { typeof(short), typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(char)
-                    AddPredifinedConvertion(
-                        typeof(char),
-                        new Type[] { },
-                        new Type[] { typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(int)
-                    AddPredifinedConvertion(
-                        typeof(int),
-                        new Type[] { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(char) },
-                        new Type[] { typeof(long), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(uint)
-                    AddPredifinedConvertion(
-                        typeof(uint),
-                        new Type[] { typeof(byte), typeof(ushort), typeof(char) },
-                        new Type[] { typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(long)
-                    AddPredifinedConvertion(
-                        typeof(long),
-                        new Type[] { typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(char) },
-                        new Type[] { typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(ulong)
-                    AddPredifinedConvertion(
-                        typeof(ulong),
-                        new Type[] { typeof(byte), typeof(ushort), typeof(uint), typeof(char) },
-                        new Type[] { typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(short)
-                    AddPredifinedConvertion(
-                        typeof(short),
-                        new Type[] { },
-                        new Type[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal) });
-                    //typeof(ushort)
-                    AddPredifinedConvertion(
-                        typeof(ushort),
-                        new Type[] { typeof(byte), typeof(char) },
-                        new Type[] { typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) });
-
-                    //typeof(string)
-                    AddPredifinedConvertion(
-                        typeof(string),
-                        new Type[] { typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) },
-                        new Type[] { });
-
-                    //typeof(Guid)
-                    AddPredifinedConvertion(
-                        typeof(Guid),
-                        new Type[] { },
-                        new Type[] { typeof(string) });
-
-                }
-                if (!CheckedTypes.Contains(from.FullName))
-                    AddType(from);
-                if (!CheckedTypes.Contains(to.FullName))
-                    AddType(to);
-                if (CanConvertTo.ContainsKey(from.FullName))
-                {
-                    System.Collections.Specialized.StringCollection sl = (System.Collections.Specialized.StringCollection)CanConvertTo[from.FullName];
-                    if (sl.Contains(to.FullName))
-                        return TypesCompatibilities.Convertable;
-                    else
-                    {
-                        if (KnownTypes.Contains(from.FullName) && KnownTypes.Contains(to.FullName) &&
-                            FoundTransform(from.FullName, to.FullName))
-                        {
-                            return TypesCompatibilities.Convertable;
-                        }
-                        else
-                            return TypesCompatibilities.No;
-                    }
-                }
-                else
-                {
-                    if (KnownTypes.Contains(from.FullName) && KnownTypes.Contains(to.FullName) &&
-                        FoundTransform(from.FullName, to.FullName))
-                    {
-                        return TypesCompatibilities.Convertable;
-                    }
-                    else
-                        return TypesCompatibilities.No;
-                }
-
-            }
-        }
-
-    }* */
 }

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqOperations.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqOperations.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business.LINQProvider.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -65,8 +66,7 @@
             Random rand = new Random();
             var parametersDictionary = sender as Dictionary<string, object>;
             List<ICSSoft.STORMNET.Business.IDataService> dsList = parametersDictionary[MultiThreadingTestTool.ParamNameSender] as List<ICSSoft.STORMNET.Business.IDataService>;
-
-            Dictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as Dictionary<string, Exception>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
 
             for (int i = 0; i < 5; i++)
             {
@@ -91,7 +91,7 @@
                 }
                 catch (Exception exception)
                 {
-                    exceptions.Add(Thread.CurrentThread.Name, exception);
+                    exceptions.TryAdd(Thread.CurrentThread.Name, exception);
                     parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
                     return;
                 }
@@ -134,8 +134,7 @@
             Random rand = new Random();
             var parametersDictionary = sender as Dictionary<string, object>;
             List<ICSSoft.STORMNET.Business.IDataService> dsList = parametersDictionary[MultiThreadingTestTool.ParamNameSender] as List<ICSSoft.STORMNET.Business.IDataService>;
-
-            Dictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as Dictionary<string, Exception>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
 
             for (int i = 0; i < 5; i++)
             {
@@ -206,7 +205,7 @@
                 }
                 catch (Exception exception)
                 {
-                    exceptions.Add(Thread.CurrentThread.Name, exception);
+                    exceptions.TryAdd(Thread.CurrentThread.Name, exception);
                     parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
                     return;
                 }

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/DetailsLoadTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/DetailsLoadTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests.Business
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading;
 
@@ -231,7 +232,7 @@
         {
             var parametersDictionary = sender as Dictionary<string, object>;
             IDataService ds = parametersDictionary[MultiThreadingTestTool.ParamNameSender] as SQLDataService;
-            Dictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as Dictionary<string, Exception>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
 
             ExternalLangDef langdef = ExternalLangDef.LanguageDef;
             langdef.DataService = ds;
@@ -257,7 +258,7 @@
                 }
                 catch (Exception exception)
                 {
-                    exceptions.Add(Thread.CurrentThread.Name, exception);
+                    exceptions.TryAdd(Thread.CurrentThread.Name, exception);
                     parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
                     return;
                 }

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/BusinessServerProviderMultiThreadTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business/BusinessServerProviderMultiThreadTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -69,7 +70,7 @@
         private void MultiThreadMethod(object sender)
         {
             var parametersDictionary = sender as Dictionary<string, object>;
-            Dictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as Dictionary<string, Exception>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
 
             // Arrange.
             var processingObject = new ObjectsToUpdateMultiThreadClass();
@@ -89,7 +90,7 @@
                 }
                 catch (Exception exception)
                 {
-                    exceptions.Add(Thread.CurrentThread.Name, exception);
+                    exceptions.TryAdd(Thread.CurrentThread.Name, exception);
                     parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
                     return;
                 }

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/ConcurrentFunctionTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/ConcurrentFunctionTests.cs
@@ -1,0 +1,75 @@
+﻿namespace NewPlatform.Flexberry.ORM.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.FunctionalLanguage;
+    using ICSSoft.STORMNET.Windows.Forms;
+
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Тесты конкурентного получения функций ограничения.
+    /// </summary>
+    public class ConcurrentFunctionTests
+    {
+        protected static readonly ExternalLangDef LangDef = ExternalLangDef.LanguageDef;
+
+        protected static readonly VariableDef IntGenVarDef = new VariableDef(LangDef.NumericType, Information.ExtractPropertyPath<TestDataObject>(x => x.Height));
+
+        private readonly ITestOutputHelper Output;
+
+        /// <summary>
+        /// Конструктор.
+        /// </summary>
+        public ConcurrentFunctionTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        [Fact]
+        public void GetFunctionDefConcurrentTest()
+        {
+            // Arrange.
+            const int length = 100;
+            var multiThreadingTestTool = new MultiThreadingTestTool(MultiThreadMethod);
+            multiThreadingTestTool.StartThreads(length);
+
+            // Assert.
+            var exception = multiThreadingTestTool.GetExceptions();
+            if (exception != null)
+            {
+                foreach (var item in exception.InnerExceptions)
+                {
+                    Output.WriteLine($"Thread {item.Key}: {item.Value}");
+                }
+
+                // Пусть так.
+                Assert.Empty(exception.InnerExceptions);
+            }
+        }
+
+        private static void MultiThreadMethod(object sender)
+        {
+            var parametersDictionary = sender as Dictionary<string, object>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
+
+            try
+            {
+                // Assert.
+                Assert.Equal(
+                    LangDef.GetFunction(LangDef.funcIsNull, IntGenVarDef),
+                    FunctionBuilder.BuildIsNull<TestDataObject>(x => x.Height));
+            }
+            catch (Exception exception)
+            {
+                exceptions.TryAdd(Thread.CurrentThread.Name, exception);
+                parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
+            }
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.Tests/MultiThreadingTestTool.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/MultiThreadingTestTool.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading;
 
@@ -53,7 +54,7 @@
         /// </summary>
         public ParameterizedThreadStart WorkerMethod = null;
 
-        private Dictionary<string, Exception> exceptions = new Dictionary<string, Exception>();
+        private ConcurrentDictionary<string, Exception> exceptions = new ConcurrentDictionary<string, Exception>();
 
         /// <summary>
         /// Получить коллекцию исключений.
@@ -160,14 +161,14 @@
             /// <summary>
             /// Вложенные исключения.
             /// </summary>
-            public Dictionary<string, Exception> InnerExceptions { get; set; } = null;
+            public ConcurrentDictionary<string, Exception> InnerExceptions { get; set; } = null;
 
             /// <summary>
             /// Создание исключения с вложением.
             /// </summary>
             /// <param name="exceptionMesage">Сообщение об исключении.</param>
             /// <param name="exceptions">Словарь исключений, возникших в потоках. В качестве ключа рекомендуется использовать имя потока.</param>
-            public ExceptionInThreads(string exceptionMesage, Dictionary<string, Exception> exceptions)
+            public ExceptionInThreads(string exceptionMesage, ConcurrentDictionary<string, Exception> exceptions)
                 : base(exceptionMesage, exceptions.Count > 0 ? exceptions.GetEnumerator().Current.Value : null)
             {
                 InnerExceptions = exceptions;


### PR DESCRIPTION
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.FoundTransform(String from, String to)
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.Check(Type from, Type to)
   at ICSSoft.STORMNET.FunctionalLanguage.Function.CheckSafetly(Boolean checkSubFunctions)
   at ICSSoft.STORMNET.FunctionalLanguage.Function.CheckWithoutSubFoldersSafetly()
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.GetFunctionDef(String functionString, Object[] parameters)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.<>c__DisplayClass34_0.<GetFunction>b__0(String k)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.GetFunction(String functionString, Object[] parameters)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionBuilder.BuildEquals(VariableDef vd, Object value)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionBuilder.BuildEquals[T](Expression`1 propExpression, Object value)
   at Iis.Eais.CurrentUserService.EaisUserContext.get_Specialist()
   at Iis.Eais.CurrentUserService.EaisUserContext.get_OrganSZ()
   at Iis.Eais.Catalogs.CurrentUserService.EaisCurrentUser.get_OrganSZ()
   at Iis.Eais.SocialProtection.Api.Controllers.CurrentUserController.GetOsz() in C:\Users\atsai\Source\Repos\eais\eais-web\Eais.SocialProtection\Eais.SocialProtection.Api\Eais.SocialProtection.Api\Controllers\CurrentUserController.cs:line 72
   at lambda_method(Closure , Object , Object[] )
   at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
...
```