### PR TITLE
Fix `CompatibilityTypeTest.Check` concurrent behaviour once again

### DIFF
--- a/ICSSoft.STORMNET.Business.ExternalLangDef/ICSSoft.STORMNET.Business.ExternalLangDef.csproj
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/ICSSoft.STORMNET.Business.ExternalLangDef.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ExternalLangDef</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.ExternalLangDef</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Business.LINQProvider/ICSSoft.STORMNET.Business.LINQProvider.csproj
+++ b/ICSSoft.STORMNET.Business.LINQProvider/ICSSoft.STORMNET.Business.LINQProvider.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business.LINQProvider</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.LINQProvider</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Business.LockService/ICSSoft.STORMNET.Business.LockService.csproj
+++ b/ICSSoft.STORMNET.Business.LockService/ICSSoft.STORMNET.Business.LockService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.LockService</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Business.MSSQLDataService/ICSSoft.STORMNET.Business.MSSQLDataService.csproj
+++ b/ICSSoft.STORMNET.Business.MSSQLDataService/ICSSoft.STORMNET.Business.MSSQLDataService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.MSSQLDataService</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +30,7 @@
     <None Remove="StyleCop.Cache" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Data" />
   </ItemGroup>
 

--- a/ICSSoft.STORMNET.Business.OracleDataService/ICSSoft.STORMNET.Business.OracleDataService.csproj
+++ b/ICSSoft.STORMNET.Business.OracleDataService/ICSSoft.STORMNET.Business.OracleDataService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.OracleDataService</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +30,7 @@
     <None Remove="StyleCop.Cache" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.22" />
   </ItemGroup>
 

--- a/ICSSoft.STORMNET.Business.PostgresDataService/ICSSoft.STORMNET.Business.PostgresDataService.csproj
+++ b/ICSSoft.STORMNET.Business.PostgresDataService/ICSSoft.STORMNET.Business.PostgresDataService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business.PostgresDataService</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Business/ICSSoft.STORMNET.Business.csproj
+++ b/ICSSoft.STORMNET.Business/ICSSoft.STORMNET.Business.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Business</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Business</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Collections/ICSSoft.STORMNET.Collections.csproj
+++ b/ICSSoft.STORMNET.Collections/ICSSoft.STORMNET.Collections.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Collections</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Collections</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.DataObject/DataObjectCache.cs
+++ b/ICSSoft.STORMNET.DataObject/DataObjectCache.cs
@@ -56,7 +56,10 @@
         {
             get
             {
-                return _objectCaches == null || _objectCaches.Count == 0;
+                lock (_objectCaches)
+                {
+                    return _objectCaches == null || _objectCaches.Count == 0;
+                }
             }
         }
 

--- a/ICSSoft.STORMNET.DataObject/ICSSoft.STORMNET.DataObject.csproj
+++ b/ICSSoft.STORMNET.DataObject/ICSSoft.STORMNET.DataObject.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.DataObject</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" Version="7.7.2" />
-    <PackageReference Include="NewPlatform.Flexberry.LogService" Version="2.0.0-beta03" />
+    <PackageReference Include="NewPlatform.Flexberry.LogService" Version="2.0.0" />
     <PackageReference Include="Unity.Abstractions" Version="5.11.6" />
   </ItemGroup>
 

--- a/ICSSoft.STORMNET.FunctionalLanguage/ICSSoft.STORMNET.FunctionalLanguage.csproj
+++ b/ICSSoft.STORMNET.FunctionalLanguage/ICSSoft.STORMNET.FunctionalLanguage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.FunctionalLanguage</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.FunctionalLanguage</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ICSSoft.STORMNET.Tools/ICSSoft.STORMNET.Tools.csproj
+++ b/ICSSoft.STORMNET.Tools/ICSSoft.STORMNET.Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.Tools</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.Tools</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,11 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.LogService" Version="2.0.0-beta03" />
+    <PackageReference Include="NewPlatform.Flexberry.LogService" Version="2.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.DirectoryServices" />
   </ItemGroup>
 

--- a/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
+++ b/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.STORMNET.UserDataTypes</RootNamespace>
     <AssemblyName>ICSSoft.STORMNET.UserDataTypes</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.CurrentUserService/NewPlatform.Flexberry.ORM.CurrentUserService.csproj
+++ b/NewPlatform.Flexberry.ORM.CurrentUserService/NewPlatform.Flexberry.ORM.CurrentUserService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.Services</RootNamespace>
     <AssemblyName>NewPlatform.Flexberry.ORM.CurrentUserService</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/LoadingCustomizationStructTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/LoadingCustomizationStructTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.FunctionalLanguage
 {
-#if !NETCORE
+#if !NETCOREAPP
     using System;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.FunctionalLanguage;
@@ -19,7 +19,7 @@
         private STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef _ldef =
             STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
 
-#if !NETCORE
+#if !NETCOREAPP
         [Fact]
         public void LcsSerializationTest()
         {

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
@@ -14,14 +14,6 @@
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/XUnitTestRunnerInitializer.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/XUnitTestRunnerInitializer.cs
@@ -2,7 +2,7 @@
 
 namespace NewPlatform.Flexberry.ORM.IntegratedTests
 {
-#if NETCORE
+#if NETCOREAPP
     using System.Configuration;
     using System.IO;
     using System.Reflection;
@@ -23,7 +23,7 @@ namespace NewPlatform.Flexberry.ORM.IntegratedTests
         public XUnitTestRunnerInitializer(IMessageSink messageSink)
             : base(messageSink)
         {
-#if NETCORE
+#if NETCOREAPP
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             string configFile = $"{Assembly.GetExecutingAssembly().Location}.config";
             string outputConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None).FilePath;

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>6.0.0-beta11</version>
+    <version>6.0.0-rc01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -17,14 +17,14 @@
       Changed
       - `DRDataService` class moved to `ICSSoft.STORMNET.Business.MSSQLDataService` assembly.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2020</copyright>
+    <copyright>Copyright New Platform Ltd 2021</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-beta11" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-rc01" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-beta11" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-rc01" />
         <dependency id="System.Data.SqlClient" version="4.6.1" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>6.0.0-beta12</version>
+    <version>6.0.0-rc01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -15,15 +15,15 @@
       Added
       - OracleDataService in it's own NuGet package.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2020</copyright>
+    <copyright>Copyright New Platform Ltd 2021</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-beta11" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-rc01" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-beta11" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-rc01" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>6.0.0-beta13</version>
+    <version>6.0.0-rc01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,7 +18,7 @@
     <copyright>Copyright New Platform Ltd 2021</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
-      <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-beta11" />
+      <dependency id="NewPlatform.Flexberry.ORM" version="6.0.0-rc01" />
       <dependency id="Npgsql" version="3.2.6" />
     </dependencies>
   </metadata>

--- a/NewPlatform.Flexberry.ORM.Test.Objects/NewPlatform.Flexberry.ORM.Tests.Objects.csproj
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/NewPlatform.Flexberry.ORM.Tests.Objects.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>NewPlatform.Flexberry.ORM.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>NewPlatform.Flexberry.ORM.Test.Objects.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NewPlatform.Flexberry.ORM.Tests.Objects.xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.Tests.BusinessServers/NewPlatform.Flexberry.ORM.Tests.BusinessServers.csproj
+++ b/NewPlatform.Flexberry.ORM.Tests.BusinessServers/NewPlatform.Flexberry.ORM.Tests.BusinessServers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <DelaySign>false</DelaySign>
     <RootNamespace>NewPlatform.Flexberry.ORM.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>
@@ -11,14 +11,6 @@
     <AssemblyOriginatorKeyFile>NewPlatform.Flexberry.ORM.Test.BusinessServers.snk</AssemblyOriginatorKeyFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NewPlatform.Flexberry.ORM.Tests.BusinessServers.xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/ConcurrentFunctionTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/ConcurrentFunctionTests.cs
@@ -31,12 +31,15 @@
             Output = output;
         }
 
+        /// <summary>
+        /// Конкурентный тест сравнения функций.
+        /// </summary>
         [Fact]
-        public void GetFunctionDefConcurrentTest()
+        public void GetFunctionConcurrentTest()
         {
             // Arrange.
             const int length = 100;
-            var multiThreadingTestTool = new MultiThreadingTestTool(MultiThreadMethod);
+            var multiThreadingTestTool = new MultiThreadingTestTool(GetFunctionMultiThreadMethod);
             multiThreadingTestTool.StartThreads(length);
 
             // Assert.
@@ -53,7 +56,7 @@
             }
         }
 
-        private static void MultiThreadMethod(object sender)
+        private static void GetFunctionMultiThreadMethod(object sender)
         {
             var parametersDictionary = sender as Dictionary<string, object>;
             ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
@@ -62,8 +65,8 @@
             {
                 // Assert.
                 Assert.Equal(
-                    LangDef.GetFunction(LangDef.funcIsNull, IntGenVarDef),
-                    FunctionBuilder.BuildIsNull<TestDataObject>(x => x.Height));
+                    LangDef.GetFunction(LangDef.funcEQ, IntGenVarDef, 152),
+                    FunctionBuilder.BuildEquals<TestDataObject>(x => x.Height, 152));
             }
             catch (Exception exception)
             {

--- a/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
+++ b/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
@@ -14,14 +14,6 @@
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/NewPlatform.Flexberry.ORM.Tests/XUnitTestRunnerInitializer.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/XUnitTestRunnerInitializer.cs
@@ -2,7 +2,7 @@
 
 namespace NewPlatform.Flexberry.ORM.Tests
 {
-#if NETCORE
+#if NETCOREAPP
     using System.Configuration;
     using System.IO;
     using System.Reflection;
@@ -23,7 +23,7 @@ namespace NewPlatform.Flexberry.ORM.Tests
         public XUnitTestRunnerInitializer(IMessageSink messageSink)
             : base(messageSink)
         {
-#if NETCORE
+#if NETCOREAPP
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             string configFile = $"{Assembly.GetExecutingAssembly().Location}.config";
             string outputConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None).FilePath;

--- a/NewPlatform.Flexberry.ORM.UnityFactory/NewPlatform.Flexberry.ORM.UnityFactory.csproj
+++ b/NewPlatform.Flexberry.ORM.UnityFactory/NewPlatform.Flexberry.ORM.UnityFactory.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ICSSoft.Services</RootNamespace>
     <AssemblyName>NewPlatform.Flexberry.ORM.UnityFactory</AssemblyName>
     <SignAssembly>true</SignAssembly>
@@ -13,14 +13,6 @@
     <CodeAnalysisRuleSet>..\Flexberry.ruleset</CodeAnalysisRuleSet>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>6.0.0-beta15</version>
+    <version>6.0.0-rc01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -35,7 +35,7 @@
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.LogService" version="2.0.0-beta03" />
+        <dependency id="NewPlatform.Flexberry.LogService" version="2.0.0" />
         <dependency id="Microsoft.Spatial" version="7.7.2" />
         <dependency id="Remotion.Linq" version="2.2.0" />
         <dependency id="SharpZipLib" version="1.2.0" />
@@ -44,7 +44,7 @@
         <dependency id="Unity.Container" version="5.11.8" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.LogService" version="2.0.0-beta03" />
+        <dependency id="NewPlatform.Flexberry.LogService" version="2.0.0" />
         <dependency id="Microsoft.Spatial" version="7.7.2" />
         <dependency id="Remotion.Linq" version="2.2.0" />
         <dependency id="SharpZipLib" version="1.2.0" />


### PR DESCRIPTION
```
System.ArgumentException
An item with the same key has already been added. Key: ICSSoft.STORMNET.KeyGen.KeyGuid
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.AddType(Type tp)
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.CheckInternal(Type from, Type to)
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.<>c__DisplayClass10_0.<Check>b__0(Int64 k)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at ICSSoft.STORMNET.FunctionalLanguage.CompatibilityTypeTest.Check(Type from, Type to)
   at ICSSoft.STORMNET.FunctionalLanguage.Function.CheckSafetly(Boolean checkSubFunctions)
   at ICSSoft.STORMNET.FunctionalLanguage.Function.CheckWithoutSubFoldersSafetly()
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.GetFunctionDef(String functionString, Object[] parameters)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.<>c__DisplayClass34_0.<GetFunction>b__0(String k)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionalLanguageDef.GetFunction(String functionString, Object[] parameters)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionBuilder.BuildEquals(VariableDef vd, Object value)
   at ICSSoft.STORMNET.FunctionalLanguage.FunctionBuilder.BuildEquals[T](Expression`1 propExpression, Object value)
   at Ecsp.Rpgu.RequestHandlers.Commands.GetOgranByForeignCodeCommand.GetTransformation(String code) in C:\Workspace\SP\eais-web\Eais.GosUslugi\Eais.GosUslugi.Jobs\Ecsp.Rpgu.RequestHandlers\Commands\GetOgranByForeignCodeCommand.cs:line 77
   at Ecsp.Rpgu.RequestHandlers.Commands.GetOgranByForeignCodeCommand.Execute(String code) in C:\Workspace\SP\eais-web\Eais.GosUslugi\Eais.GosUslugi.Jobs\Ecsp.Rpgu.RequestHandlers\Commands\GetOgranByForeignCodeCommand.cs:line 49
   at Iis.Eais.GosUslugi.Jobs.Tests.Ecsp.Rpgu.Commands.GetOgranByForeignCodeCommandTests.ExecuteValidTestLen() in C:\Workspace\SP\eais-web\Eais.GosUslugi\Eais.GosUslugi.Jobs\Eais.GosUslugi.Jobs.Tests\Ecsp\Rpgu\Commands\GetOgranByForeignCodeCommandTests.cs:line 61
```