### PR TITLE
Fixed `KeyGenerator.KeyType` concurrent behaviour

### DIFF
--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -678,7 +678,7 @@
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang =
                     FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 var variable = new FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(dataObjectType).KeyType),
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dataObjectType)),
                     FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.StormMainObjectKey);
                 object readingkey = dobject.__PrimaryKey;
                 object prevPrimaryKey = null;
@@ -791,7 +791,7 @@
 
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(doType).KeyType), "STORMMainObjectKey");
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(doType)), "STORMMainObjectKey");
                 object readingkey = dobject.__PrimaryKey;
                 object prevPrimaryKey = null;
                 if (dobject.Prototyped)
@@ -1827,7 +1827,7 @@
 
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(dataObjectView.DefineClassType).KeyType), "STORMMainObjectKey");
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dataObjectView.DefineClassType)), "STORMMainObjectKey");
                 object[] keys = new object[ALKeys.Count + 1];
                 ALKeys.CopyTo(keys, 1);
                 keys[0] = var;
@@ -4043,7 +4043,7 @@
                     FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
 
                     FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                        lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(dobject.GetType()).KeyType), prkeyStorName);
+                        lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dobject.GetType())), prkeyStorName);
                     FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, dobject.__PrimaryKey);
 
                     if (UpdaterFunction != null)
@@ -4119,7 +4119,7 @@
             FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
 
             FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(view.DefineClassType).KeyType), prkeyStorName);
+                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(view.DefineClassType)), prkeyStorName);
             FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, mainkey);
 
             LoadingCustomizationStruct cs = new LoadingCustomizationStruct(GetInstanceId());
@@ -5460,7 +5460,7 @@
                             query += values + nl + " WHERE ";
                             FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                             var var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(t).KeyType), Information.GetPrimaryKeyStorageName(t));
+                                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(t)), Information.GetPrimaryKeyStorageName(t));
                             FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, processingObject.__PrimaryKey);
                             if (updaterobject != null)
                             {
@@ -5488,7 +5488,7 @@
                         query += values + nl + " WHERE ";
                         FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                         var var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                            lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(processingObject.GetType()).KeyType), Information.GetPrimaryKeyStorageName(typeOfProcessingObject));
+                            lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(processingObject.GetType())), Information.GetPrimaryKeyStorageName(typeOfProcessingObject));
                         FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, processingObject.__PrimaryKey);
                         if (updaterobject != null)
                         {

--- a/ICSSoft.STORMNET.Business/XMLDataService/XMLDataService.cs
+++ b/ICSSoft.STORMNET.Business/XMLDataService/XMLDataService.cs
@@ -296,7 +296,7 @@
                 var lc = new LoadingCustomizationStruct(GetInstanceId());
                 var lang = FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 var var = new FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(doType).KeyType), "STORMMainObjectKey");
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(doType)), "STORMMainObjectKey");
                 object prevPrimaryKey = null;
 
                 if (dobject.Prototyped)
@@ -513,7 +513,7 @@
 
                 var customizationStruct = new LoadingCustomizationStruct(_instanceId);
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
-                var var = new FunctionalLanguage.VariableDef(lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(dataObjectView.DefineClassType).KeyType),
+                var var = new FunctionalLanguage.VariableDef(lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dataObjectView.DefineClassType)),
                                                              "STORMMainObjectKey");
                 var keys = new object[alKeys.Count + 1];
                 alKeys.CopyTo(keys, 1);
@@ -1207,7 +1207,7 @@
             // string prevDicValue = "";
             FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
             var var = new FunctionalLanguage.VariableDef(
-                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.Generator(view.DefineClassType).KeyType), prkeyStorName);
+                lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(view.DefineClassType)), prkeyStorName);
             FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, mainkey);
             var cs = new LoadingCustomizationStruct(GetInstanceId());
             cs.Init(new ColumnsSortDef[0], func, new[] { view.DefineClassType }, view, new string[0]);

--- a/ICSSoft.STORMNET.DataObject/Information.cs
+++ b/ICSSoft.STORMNET.DataObject/Information.cs
@@ -1684,7 +1684,7 @@
 
                     if (propname == "__PrimaryKey")
                     {
-                        res = KeyGen.KeyGenerator.Generator(declarationType).KeyType;
+                        res = KeyGen.KeyGenerator.KeyType(declarationType);
                     }
                     else
                     {
@@ -1765,7 +1765,7 @@
 
                 if (propname == "__PrimaryKey")
                 {
-                    res = KeyGen.KeyGenerator.Generator(declarationType).KeyType;
+                    res = KeyGen.KeyGenerator.KeyType(declarationType);
                 }
                 else
                 {

--- a/ICSSoft.STORMNET.FunctionalLanguage/SQLWhereLanguageDef.cs
+++ b/ICSSoft.STORMNET.FunctionalLanguage/SQLWhereLanguageDef.cs
@@ -104,7 +104,7 @@
             if (type.IsSubclassOf(typeof(DataObject)))
             {
                 // подменяем типом первичного ключа
-                type = ((KeyGen.BaseKeyGenerator)Activator.CreateInstance(Information.GetKeyGeneratorType(type))).KeyType;
+                type = KeyGen.KeyGenerator.KeyType(type);
             }
 
             if (type.IsEnum)

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/KeyGeneratorTests.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/KeyGeneratorTests.cs
@@ -1,0 +1,75 @@
+﻿namespace NewPlatform.Flexberry.ORM.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.KeyGen;
+
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Тесты для класса <see cref="KeyGenerator"/>.
+    /// </summary>
+    public class KeyGeneratorTests
+    {
+        private readonly ITestOutputHelper Output;
+
+        /// <summary>
+        /// Конструктор.
+        /// </summary>
+        /// <param name="output">Поток вывода теста.</param>
+        public KeyGeneratorTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        /// <summary>
+        /// Конкурентный тест получения типа ключа <see cref="KeyGenerator.KeyType(DataObject)" />.
+        /// </summary>
+        /// <remarks>Падает крайне редко.</remarks>
+        [Fact]
+        public void KeyTypeConcurrentTest()
+        {
+            // Arrange.
+            const int length = 100;
+            var multiThreadingTestTool = new MultiThreadingTestTool(KeyTypeMultiThreadMethod);
+            multiThreadingTestTool.StartThreads(length);
+
+            // Assert.
+            var exception = multiThreadingTestTool.GetExceptions();
+            if (exception != null)
+            {
+                foreach (var item in exception.InnerExceptions)
+                {
+                    Output.WriteLine($"Thread {item.Key}: {item.Value}");
+                }
+
+                // Пусть так.
+                Assert.Empty(exception.InnerExceptions);
+            }
+        }
+
+        private void KeyTypeMultiThreadMethod(object sender)
+        {
+            var parametersDictionary = sender as Dictionary<string, object>;
+            ConcurrentDictionary<string, Exception> exceptions = parametersDictionary[MultiThreadingTestTool.ParamNameExceptions] as ConcurrentDictionary<string, Exception>;
+
+            try
+            {
+                // Assert.
+                var dobjType = typeof(Медведь);
+                var keyType = KeyGenerator.KeyType(dobjType);
+                Assert.Equal(typeof(KeyGuid), keyType);
+            }
+            catch (Exception exception)
+            {
+                exceptions.TryAdd(Thread.CurrentThread.Name, exception);
+                parametersDictionary[MultiThreadingTestTool.ParamNameWorking] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
```
System.NullReferenceException
Object reference not set to an instance of an object.
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at ICSSoft.STORMNET.KeyGen.KeyGenerator.KeyType(Type dataobjecttype)
   at ICSSoft.STORMNET.KeyGen.KeyGenerator.KeyType(DataObject dataobject)
   at ICSSoft.STORMNET.DataObject.set___PrimaryKey(Object value)
   at ICSSoft.STORMNET.KeyGen.KeyGenerator.Generate(DataObject dataobject, Object sds)
   at ICSSoft.STORMNET.DataObject..ctor()
   at Iis.Eais.GosUslugi.ChlenSemi..ctor()
   at Iis.Eais.GosUslugi.Tests.MVRequestProcessors.DataSets.ChlenSemiDataSet..cctor() in C:\Workspace\SP\eais-gosuslugi\Eais.GosUslugi\Eais.GosUslugi.Tests\MVRequestProcessors\DataSets\ChlenSemiDataSet.cs:line 10
```
