### PR TITLE
Fix #173. Skip null master properties for last update queries.

### DIFF
--- a/Doxygen/DoxyConfig
+++ b/Doxygen/DoxyConfig
@@ -821,7 +821,10 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */*Tests*/
+EXCLUDE_PATTERNS       = */NewPlatform.Flexberry.ORM.IntegratedTests/*
+EXCLUDE_PATTERNS      += */NewPlatform.Flexberry.ORM.Test.Objects/*
+EXCLUDE_PATTERNS      += */NewPlatform.Flexberry.ORM.Tests/*
+EXCLUDE_PATTERNS      += */NewPlatform.Flexberry.ORM.Tests.BusinessServers/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -4844,15 +4844,19 @@
                             foreach (var propertyStorageName in propertyStorageNames)
                             {
                                 // Добавляем свойство в запрос на изменение объекта.
-                                if (alteredList.ContainsKey(createdObject))
+                                string propValue = propsCollection.Get(propertyStorageName);
+                                if (propValue != ConvertValueToQueryValueString(null))
                                 {
-                                    alteredList[createdObject].Add(propertyStorageName, propsCollection.Get(propertyStorageName));
-                                }
-                                else
-                                {
-                                    var alteredCollection = new Collections.CaseSensivityStringDictionary();
-                                    alteredCollection.Add(propertyStorageName, propsCollection.Get(propertyStorageName));
-                                    alteredList.Add(createdObject, alteredCollection);
+                                    if (alteredList.ContainsKey(createdObject))
+                                    {
+                                        alteredList[createdObject].Add(propertyStorageName, propValue);
+                                    }
+                                    else
+                                    {
+                                        var alteredCollection = new Collections.CaseSensivityStringDictionary();
+                                        alteredCollection.Add(propertyStorageName, propValue);
+                                        alteredList.Add(createdObject, alteredCollection);
+                                    }
                                 }
 
                                 // Удаляем из списка свойств на изменение в запросе на создание объекта.

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
@@ -1186,7 +1186,7 @@
         /// <summary>
         /// Тест для проверки записи иерархической сущности. Проверяем, что нет лишних Update-запросов в БД.
         /// </summary>
-        [Fact(Skip = "Fix https://github.com/Flexberry/NewPlatform.Flexberry.ORM/pull/168 another way.")]
+        [Fact]
         public void InsertHierarchyTest()
         {
             foreach (IDataService dataService in DataServices)


### PR DESCRIPTION
Removed unnecessary `set MasterName = NULL` after inserting object:
```
UPDATE STORMAuField SET 
MainChange_m0 = NULL
 WHERE ( primaryKey = '{04ed436b-17c5-40ae-aa7c-09c9fa30a84b}')
```