### PR TITLE
Оптимизировано удаление агрегатора с незагруженными детейлами.

### DIFF
--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -441,11 +441,11 @@
             if (!string.IsNullOrEmpty(orderByExpr))
             {
                 innerQuery = innerQuery.Substring(0, innerQuery.Length - orderByExpr.Length);
-                innerQuery = innerQuery.Insert(fromInd, "," + nl + "row_number() over (" + orderByExpr + ") as \"RowNumber\"" + nl);
+                innerQuery = innerQuery.Insert(fromInd, $",{nl}row_number() over ({orderByExpr}) as \"RowNumber\"{nl}");
             }
             else
             {
-                innerQuery = innerQuery.Insert(fromInd, "," + nl + "row_number() over (ORDER BY " + PutIdentifierIntoBrackets("STORMMainObjectKey") + " ) as \"RowNumber\"" + nl);
+                innerQuery = innerQuery.Insert(fromInd, $",{nl}row_number() over (ORDER BY {PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey)} ) as \"RowNumber\"{nl}");
             }
 
             string query = string.Format(
@@ -455,7 +455,7 @@
                 LimitFunction2SQLWhere(limitFunction),
                 maxResults.HasValue ? (" TOP " + maxResults) : string.Empty,
                 orderByExpr,
-                PutIdentifierIntoBrackets("STORMMainObjectKey"));
+                PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey));
 
             object state = null;
             object[][] res = ReadFirst(query, ref state, lcs.LoadingBufferSize);
@@ -762,12 +762,14 @@
         {
             if (dataObjectView == null)
             {
-                throw new ArgumentNullException("dataObjectView", "Не указано представление для загрузки объекта. Обратитесь к разработчику.");
+                throw new ArgumentNullException(nameof(dataObjectView), "Не указано представление для загрузки объекта. Обратитесь к разработчику.");
             }
+
+            Type doType = dobject.GetType();
 
             if (!DoNotChangeCustomizationString && ChangeCustomizationString != null)
             {
-                string cs = ChangeCustomizationString(new Type[] { dobject.GetType() });
+                string cs = ChangeCustomizationString(new Type[] { doType });
                 customizationString = string.IsNullOrEmpty(cs) ? customizationString : cs;
             }
 
@@ -786,13 +788,11 @@
                     prv_AddMasterObjectsToCache(dobject, new System.Collections.ArrayList(), DataObjectCache);
                 }
 
-                System.Type doType = dobject.GetType();
-
                 LoadingCustomizationStruct lc = new LoadingCustomizationStruct(GetInstanceId());
 
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(doType)), "STORMMainObjectKey");
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(doType)), SQLWhereLanguageDef.StormMainObjectKey);
                 object readingkey = dobject.__PrimaryKey;
                 object prevPrimaryKey = null;
                 if (dobject.Prototyped)
@@ -890,12 +890,12 @@
         {
             if (dataObjectView == null)
             {
-                throw new ArgumentNullException("dataObjectView", "Не указано представление для дозагрузки объекта. Обратитесь к разработчику.");
+                throw new ArgumentNullException(nameof(dataObjectView), "Не указано представление для дозагрузки объекта. Обратитесь к разработчику.");
             }
 
             if (dataObject == null)
             {
-                throw new ArgumentNullException("dataObject", "Не указан объект для дозагрузки. Обратитесь к разработчику.");
+                throw new ArgumentNullException(nameof(dataObject), "Не указан объект для дозагрузки. Обратитесь к разработчику.");
             }
 
             Type doType = dataObject.GetType();
@@ -1198,10 +1198,10 @@
 
             foreach (object par in func.Parameters)
             {
-                if (par is ICSSoft.STORMNET.FunctionalLanguage.VariableDef)
+                if (par is VariableDef varDef)
                 {
-                    string n = (par as ICSSoft.STORMNET.FunctionalLanguage.VariableDef).StringedView;
-                    if (n != null && n.ToLower() == "stormmainobjectkey")
+                    string n = varDef.StringedView;
+                    if (n != null && string.Equals(n, SQLWhereLanguageDef.StormMainObjectKey, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }
@@ -1457,7 +1457,7 @@
 
                 if (!ForReadValues)
                 {
-                    props.Add(PutIdentifierIntoBrackets("STORMMainObjectKey"));
+                    props.Add(PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey));
                     for (int i = 0; i < MaxCountKeys; i++)
                     {
                         if (StorageType == StorageTypeEnum.HierarchicalStorage)
@@ -1472,8 +1472,8 @@
                 }
                 #endregion
 
-                string colsPart = Query.Substring(Query.IndexOf(System.Text.RegularExpressions.Regex.Match(Query,
-                    @"([.]*(\""\w*\b\""))* as " + PutIdentifierIntoBrackets("STORMMainObjectKey")).Value));
+                string colsPart = Query.Substring(Query.IndexOf(Regex.Match(Query,
+                    @"([.]*(\""\w*\b\""))* as " + PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey)).Value));
                 if (mustNewgenerate)
                 {
                     Query = "SELECT ";
@@ -1722,11 +1722,11 @@
                 if (!string.IsNullOrEmpty(orderByExpr))
                 {
                     resQuery = resQuery.Replace(orderByExpr, string.Empty);
-                    resQuery = resQuery.Insert(fromInd, "," + nl + "row_number() over (" + orderByExpr + ") as \"RowNumber\"" + nl);
+                    resQuery = resQuery.Insert(fromInd, $",{nl}row_number() over ({orderByExpr}) as \"RowNumber\"{nl}");
                 }
                 else
                 {
-                    resQuery = resQuery.Insert(fromInd, "," + nl + "row_number() over (ORDER BY \"STORMMainObjectKey\") as \"RowNumber\"" + nl);
+                    resQuery = resQuery.Insert(fromInd, $",{nl}row_number() over (ORDER BY \"{SQLWhereLanguageDef.StormMainObjectKey}\") as \"RowNumber\"{nl}");
                 }
 
                 resQuery = селектСамогоВерхнегоУр + nl + "FROM (" + nl + resQuery + ") rn" + nl + "where \"RowNumber\" between " + customizationStruct.RowNumber.StartRow.ToString() + " and " + customizationStruct.RowNumber.EndRow.ToString() + nl +
@@ -1828,7 +1828,7 @@
 
                 FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                 FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dataObjectView.DefineClassType)), "STORMMainObjectKey");
+                    lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dataObjectView.DefineClassType)), SQLWhereLanguageDef.StormMainObjectKey);
                 object[] keys = new object[ALKeys.Count + 1];
                 ALKeys.CopyTo(keys, 1);
                 keys[0] = var;
@@ -2908,16 +2908,16 @@
                                 out pointExist) + " as " + brackedIdent;
 
                             if (!string.IsNullOrEmpty(namespacewithpoint)
-                                && translatedExpression.ToLower().Contains("stormmainobjectkey"))
+                                && translatedExpression.IndexOf(SQLWhereLanguageDef.StormMainObjectKey, StringComparison.OrdinalIgnoreCase) >= 0)
                             {
-                                string mainObjectKeyReplace = "{" + namespacewithpoint + "STORMMainObjectKey}";
+                                string mainObjectKeyReplace = $"{{{namespacewithpoint}{SQLWhereLanguageDef.StormMainObjectKey}}}";
 
                                 if (!mainKeyByNamespace.ContainsKey(prop.source.Name))
                                 {
                                     mainKeyByNamespace.Add(prop.source.Name, mainObjectKeyReplace);
                                 }
 
-                                var regex = new Regex("\"?STORMMainObjectKey\"?", RegexOptions.IgnoreCase);
+                                var regex = new Regex($"\"?{SQLWhereLanguageDef.StormMainObjectKey}\"?", RegexOptions.IgnoreCase);
                                 translatedExpression = regex.Replace(translatedExpression, mainObjectKeyReplace);
                             }
                         }
@@ -2942,7 +2942,7 @@
                 firstSelectPartFields = false;
             }
 
-            string MainKeyBracked = PutIdentifierIntoBrackets("STORMMainObjectKey");
+            string MainKeyBracked = PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey);
             string MainKey = PutIdentifierIntoBrackets(storageStruct.sources.Name + "0") + "." + PutIdentifierIntoBrackets(storageStruct.sources.storage[0].PrimaryKeyStorageName) + " as " + MainKeyBracked;
 
             string MainStor = storageStruct.sources.storage[0].Storage;
@@ -3093,7 +3093,9 @@
                 return "NULL";
             }
 
-            if (ConverterToQueryValueString?.IsSupported(value.GetType()) == true)
+            Type valType = value.GetType();
+
+            if (ConverterToQueryValueString?.IsSupported(valType) == true)
             {
                 return ConverterToQueryValueString.ConvertToQueryValueString(value);
             }
@@ -3103,7 +3105,6 @@
                 return convertibleValue.ConvertToQueryValueString();
             }
 
-            System.Type valType = value.GetType();
             if (valType == typeof(string))
             {
                 if ((string)value == string.Empty)
@@ -3392,13 +3393,13 @@
                 if (!bExistsFounded)
                 {
                     sw = System.Text.RegularExpressions.Regex.Replace(sw,
-                        PutIdentifierIntoBrackets("STORMMainObjectKey"),
+                        PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey),
                         PutIdentifierIntoBrackets(StorageStruct[0].sources.Name + "0") + "." +
                         PutIdentifierIntoBrackets(StorageStruct[0].sources.storage[0].PrimaryKeyStorageName),
                         System.Text.RegularExpressions.RegexOptions.IgnoreCase);
                 }
 
-                string sPK = PutIdentifierIntoBrackets("STORMGENERATEDQUERY") + "." + PutIdentifierIntoBrackets("STORMMainObjectKey");
+                string sPK = PutIdentifierIntoBrackets("STORMGENERATEDQUERY") + "." + PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey);
                 int k = -1;
                 while (sw.IndexOf(sPK, k + 1) > 0)
                 {
@@ -4029,9 +4030,10 @@
             StringCollection DeleteTables,
             SortedList TableOperations)
         {
+            var doType = dobject.GetType();
             System.Type[] dots = (StorageType == StorageTypeEnum.HierarchicalStorage)
-                ? Information.GetCompatibleTypesForTypeConvertion(dobject.GetType())
-                : new Type[] { dobject.GetType() };
+                ? Information.GetCompatibleTypesForTypeConvertion(doType)
+                : new Type[] { doType };
             for (int i = 0; i < dots.Length; i++)
             {
                 string tableName = Information.GetClassStorageName(dots[i]);
@@ -4041,7 +4043,7 @@
                     FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
 
                     FunctionalLanguage.VariableDef var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                        lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(dobject.GetType())), prkeyStorName);
+                        lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(doType)), prkeyStorName);
                     FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, dobject.__PrimaryKey);
 
                     if (UpdaterFunction != null)
@@ -4124,25 +4126,28 @@
             object state = null;
             BusinessServer[] bs = BusinessServerProvider.GetBusinessServer(view.DefineClassType, DataServiceObjectEvents.OnDeleteFromStorage, this);
             if (bs != null && bs.Length > 0)
-            { // Если на детейловые объекты навешены бизнес-сервера, то тогда детейлы будут подгружены
+            {
+                // Если на детейловые объекты навешены бизнес-сервера, то тогда детейлы будут подгружены
                 updateobjects = LoadObjectsByExtConn(cs, ref state, DataObjectCache, dbTransactionWrapper.Connection, dbTransactionWrapper.Transaction);
             }
             else
             {
                 if (AuditService.IsTypeAuditable(view.DefineClassType))
-                { /* Аудиту необходимо зафиксировать удаление детейлов.
-                   * Здесь в аудит идут уже актуальные детейлы, поскольку на них нет бизнес-серверов,
-                   * а бизнес-сервера основного объекта уже выполнились.
-                   */
+                {
+                    /* Аудиту необходимо зафиксировать удаление детейлов.
+                    * Здесь в аудит идут уже актуальные детейлы, поскольку на них нет бизнес-серверов,
+                    * а бизнес-сервера основного объекта уже выполнились.
+                    */
                     DataObject[] detailObjects = LoadObjectsByExtConn(cs, ref state, DataObjectCache, dbTransactionWrapper.Connection, dbTransactionWrapper.Transaction);
                     if (detailObjects != null)
                     {
                         foreach (var detailObject in detailObjects)
-                        {// Мы будем сии детейлы удалять, поэтому им необходимо проставить соответствующий статус
+                        {
+                            // Мы будем сии детейлы удалять, поэтому им необходимо проставить соответствующий статус
                             detailObject.SetStatus(ObjectStatus.Deleted);
                         }
 
-                        extraProcessingObjects.AddRange(detailObjects.ToList());
+                        extraProcessingObjects.AddRange(detailObjects);
                     }
                 }
 
@@ -4154,7 +4159,7 @@
                     for (int i = 0; i < types.Length; i++)
                     {
                         string tableName = Information.GetClassStorageName(types[i]);
-                        string selectQuery = PutIdentifierIntoBrackets(Information.GetPrimaryKeyStorageName(view.DefineClassType)) + " IN ( SELECT " + PutIdentifierIntoBrackets("STORMMainObjectKey") + " FROM (" + sq + " ) a )";
+                        string selectQuery = PutIdentifierIntoBrackets(Information.GetPrimaryKeyStorageName(view.DefineClassType)) + " IN ( SELECT " + PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey) + " FROM (" + sq + " ) a )";
                         if (!deleteDictionary.ContainsKey(tableName))
                         {
                             deleteDictionary.Add(tableName, new List<string>());
@@ -4168,7 +4173,7 @@
                 else
                 {
                     string tableName = Information.GetClassStorageName(view.DefineClassType);
-                    string selectQuery = PutIdentifierIntoBrackets(Information.GetPrimaryKeyStorageName(view.DefineClassType)) + " IN ( SELECT " + PutIdentifierIntoBrackets("STORMMainObjectKey") + " FROM (" + sq + " ) a )";
+                    string selectQuery = PutIdentifierIntoBrackets(Information.GetPrimaryKeyStorageName(view.DefineClassType)) + " IN ( SELECT " + PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey) + " FROM (" + sq + " ) a )";
                     if (!deleteDictionary.ContainsKey(tableName))
                     {
                         deleteDictionary.Add(tableName, new List<string>());
@@ -4970,7 +4975,7 @@
                                 }
                             }
 
-                            string thisTable = Information.GetClassStorageName(processingObject.GetType());
+                            string thisTable = Information.GetClassStorageName(typeOfProcessingObject);
                             foreach (DataObject detobj in smastersObj)
                             {
                                 if (!ContainsKeyINProcessing(processingObjectsKeys, detobj))
@@ -5008,7 +5013,7 @@
 
                     case STORMDO.ObjectStatus.Created:
                         {
-                            if (AuditService.IsTypeAuditable(processingObject.GetType()))
+                            if (AuditService.IsTypeAuditable(typeOfProcessingObject))
                             {
                                 AuditService.AddCreateAuditInformation(processingObject);
                             }
@@ -5074,7 +5079,7 @@
 
                     case STORMDO.ObjectStatus.Altered:
                         {
-                            if (AuditService.IsTypeAuditable(processingObject.GetType()))
+                            if (AuditService.IsTypeAuditable(typeOfProcessingObject))
                             {
                                 AuditService.AddEditAuditInformation(processingObject);
                             }
@@ -5192,9 +5197,10 @@
             List<Type> depList = GetOrderFromDependencies(dependencies);
             foreach (DataObject processingObject in processingObjects)
             {
-                if (depList.IndexOf(processingObject.GetType()) < 0)
+                Type typeOfProcessingObject = processingObject.GetType();
+                if (depList.IndexOf(typeOfProcessingObject) < 0)
                 {
-                    depList.Add(processingObject.GetType());
+                    depList.Add(typeOfProcessingObject);
                 }
             }
 
@@ -5300,12 +5306,11 @@
                     if (deleteList.ContainsKey(identifier))
                     {
                         FunctionalLanguage.Function func = (STORMFunction)deleteList[identifier];
-                        string Query = "DELETE FROM " + PutIdentifierIntoBrackets(identifier) + " WHERE " +
-                                       LimitFunction2SQLWhere(func);
-                        if (!deleteQueries.Contains(Query))
+                        string query = $"DELETE FROM {PutIdentifierIntoBrackets(identifier)} WHERE {LimitFunction2SQLWhere(func)}";
+                        if (!deleteQueries.Contains(query))
                         {
                             deleteTables.Add(identifier);
-                            deleteQueries.Add(Query);
+                            deleteQueries.Add(query);
                         }
                     }
 
@@ -5314,7 +5319,7 @@
                         var deleteDetailQueries = deleteDictionary[identifier];
                         foreach (string s in deleteDetailQueries)
                         {
-                            string query = "DELETE FROM " + PutIdentifierIntoBrackets(identifier) + " WHERE " + s;
+                            string query = $"DELETE FROM {PutIdentifierIntoBrackets(identifier)} WHERE {s}";
                             if (!deleteQueries.Contains(query))
                             {
                                 deleteTables.Add(identifier);
@@ -5468,7 +5473,7 @@
                         query += values + nl + " WHERE ";
                         FunctionalLanguage.SQLWhere.SQLWhereLanguageDef lang = ICSSoft.STORMNET.FunctionalLanguage.SQLWhere.SQLWhereLanguageDef.LanguageDef;
                         var var = new ICSSoft.STORMNET.FunctionalLanguage.VariableDef(
-                            lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(processingObject.GetType())), Information.GetPrimaryKeyStorageName(typeOfProcessingObject));
+                            lang.GetObjectTypeForNetType(KeyGen.KeyGenerator.KeyType(typeOfProcessingObject)), Information.GetPrimaryKeyStorageName(typeOfProcessingObject));
                         FunctionalLanguage.Function func = lang.GetFunction(lang.funcEQ, var, processingObject.__PrimaryKey);
                         if (updaterobject != null)
                         {

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.Performance.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.Performance.cs
@@ -1,0 +1,71 @@
+﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests.Business
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.Business;
+
+    using NewPlatform.Flexberry.ORM.Tests;
+
+    using Xunit;
+
+    /// <summary>
+    /// Тесты производительности <see cref="SQLDataService" />.
+    /// </summary>
+    public partial class SQLDataServiceTest
+    {
+        /// <summary>
+        /// Тест удаления детейлов.
+        /// </summary>
+        [Fact(Skip = "Для ручного тестирования")]
+        public void DeleteNotLoadedAgregatorWithDetailsTest()
+        {
+            foreach (IDataService dataService in DataServices)
+            {
+                // Arrange.
+                const int length = 1000;
+                IEnumerable<int> range = Enumerable.Range(0, length);
+                var author = new Пользователь
+                {
+                    Логин = "BrainStorm",
+                };
+                dataService.UpdateObject(author);
+                var contest = new Конкурс
+                {
+                    Название = "Мозговой штурм",
+                    Организатор = author,
+                };
+                dataService.UpdateObject(contest);
+
+                // Генерируем много объектов с детейлами.
+                DataObject[] objs = range.Select(
+                    x => new Идея
+                    {
+                        СуммаБаллов = x,
+                        Автор = author,
+                        Конкурс = contest,
+                    }).ToArray();
+                dataService.UpdateObjects(ref objs);
+
+                // Act.
+                // Удаляем все объекты.
+                DataObject[] objsForDelete = objs.Select(
+                    x =>
+                    {
+                        var obj = PKHelper.CreateDataObject<Идея>(x);
+                        obj.SetStatus(ObjectStatus.Deleted);
+                        return obj;
+                    }).ToArray();
+
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                dataService.UpdateObjects(ref objsForDelete);
+                stopwatch.Stop();
+
+                output.WriteLine($"{nameof(DeleteNotLoadedAgregatorWithDetailsTest)}@{dataService.GetType().Name}: elapsed {stopwatch.ElapsedMilliseconds}");
+            }
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
@@ -8,24 +8,30 @@
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;
+    using ICSSoft.STORMNET.Exceptions;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.UserDataTypes;
-    using Xunit;
+
     using NewPlatform.Flexberry.ORM.Tests;
-    using ICSSoft.STORMNET.Exceptions;
+
+    using Xunit;
+    using Xunit.Abstractions;
 
     /// <summary>
     /// Тестовый класс для <see cref="SQLDataService"/>.
     /// </summary>
     public partial class SQLDataServiceTest : BaseIntegratedTest
     {
+        private readonly ITestOutputHelper output;
+
         /// <summary>
         /// Конструктор.
         /// </summary>
-        public SQLDataServiceTest()
+        public SQLDataServiceTest(ITestOutputHelper output)
             : base("SQLDS")
         {
+            this.output = output ?? throw new ArgumentNullException(nameof(output));
         }
 
         /// <summary>
@@ -180,7 +186,7 @@
                 Assert.Equal(1, result.Count);
                 Assert.True(result[1].IndexOf("{") > -1);
 
-                Console.WriteLine(result[1]);
+                output.WriteLine(result[1]);
             }
         }
 


### PR DESCRIPTION
Default
```
100
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 507
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 961

1000
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 23811
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 31099

5000 (10k are unreachable)
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 550602
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 639335
```

Optimized
```
100
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 795
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 700

1000
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 7341
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 6808

10000
DeleteNotLoadedAgregatorWithDetailsTest@PostgresDataService: elapsed 80111
DeleteNotLoadedAgregatorWithDetailsTest@MSSQLDataService: elapsed 82052
```