### PR TITLE
Fix ExternalLangDef concurrency

### DIFF
--- a/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/ExternalLangDef.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/ExternalLangDef.cs
@@ -20,34 +20,23 @@
         {
             fieldDataObjectType.SimplificationValue = DataObjectToSimpleValue;
             fieldDataObjectType.UnSimplificationValue = SimpleValueToDataObject;
+            ChFuncNames = new List<string>
+            {
+                "Count", "SUM", funcCountWithLimit, "ExistExact", "Exist", "AVG", "MAX", "MIN", funcSumWithLimit, funcAvgWithLimit, funcMaxWithLimit, funcMinWithLimit, "ExistAll", "ExistAllExact",
+            };
         }
-
-        private static ExternalLangDef _lngDef = null;
-        private static string _objNull = "CONST";
 
         /// <summary>
         /// Статический ExternalLangDef, используется для получения функций.
         /// </summary>
-        public static ExternalLangDef LanguageDef
-        {
-            get
-            {
-                if (_lngDef != null)
-                {
-                    return _lngDef;
-                }
-
-                lock (_objNull)
-                {
-                    return _lngDef ?? (_lngDef = new ExternalLangDef());
-                }
-            }
-        }
+        public static ExternalLangDef LanguageDef { get; } = new ExternalLangDef();
 
         /// <summary>
         /// сервис данных для построения подзапросов.
         /// </summary>
         private Business.IDataService m_objDataService;
+
+        private readonly List<string> ChFuncNames;
 
         /// <summary>
         /// Сервис данных для построения подзапросов. Если не указан, используется DataServiceProvider.DataService.
@@ -973,20 +962,12 @@
             get { return base.MaxFuncID + 35; }
         }
 
-        private System.Collections.Specialized.StringCollection ChFuncNames = null;
-
         public override string[] GetExistingVariableNames(ICSSoft.STORMNET.FunctionalLanguage.Function f)
         {
             var al = new ArrayList();
             if (retVars != null)
             {
                 al.AddRange(retVars);
-            }
-
-            if (ChFuncNames == null)
-            {
-                ChFuncNames = new System.Collections.Specialized.StringCollection();
-                ChFuncNames.AddRange(new[] { "Count", "SUM", funcCountWithLimit, "ExistExact", "Exist", "AVG", "MAX", "MIN", funcSumWithLimit, funcAvgWithLimit, funcMaxWithLimit, funcMinWithLimit, "ExistAll", "ExistAllExact" });
             }
 
             if (ChFuncNames.Contains(f.FunctionDef.StringedView))


### PR DESCRIPTION
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Collections.ArrayList.Contains(Object item)
   at ICSSoft.STORMNET.Windows.Forms.ExternalLangDef.GetExistingVariableNames(Function f)
   at ICSSoft.STORMNET.Business.SQLDataService.AddPropsByLimits(View curView, View OldView, Function func)
   at ICSSoft.STORMNET.Business.SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct customizationStruct, Boolean ForReadValues, StorageStructForView[]& StorageStruct, Boolean Optimized)
   at ICSSoft.STORMNET.Business.PostgresDataService.GenerateSQLSelect(LoadingCustomizationStruct customizationStruct, Boolean ForReadValues, StorageStructForView[]& StorageStruct, Boolean Optimized)
   at ICSSoft.STORMNET.Business.SQLDataService.GenerateSQLSelect(LoadingCustomizationStruct customizationStruct, Boolean Optimized)
   at ICSSoft.STORMNET.Business.PostgresDataService.GenerateSQLSelect(LoadingCustomizationStruct customizationStruct, Boolean optimized)
   at ICSSoft.STORMNET.Business.SQLDataService.GetObjectsCount(LoadingCustomizationStruct customizationStruct)
   at NewPlatform.Flexberry.ORM.ODataService.Controllers.DataObjectController.LoadObjects(LoadingCustomizationStruct lcs, Int32& count, Boolean callExecuteCallbackBeforeGet, Boolean callGetObjectsCount, Boolean callExecuteCallbackAfterGet)
   at NewPlatform.Flexberry.ORM.ODataService.Controllers.DataObjectController.ExecuteExpression()
   at NewPlatform.Flexberry.ORM.ODataService.Controllers.DataObjectController.Get()
```