### PR TITLE
Optimize select query generation

### DIFF
--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -1481,10 +1481,7 @@
                         Query,
                         @"([.]*(\""\w*\b\""))* as " + PutIdentifierIntoBrackets(SQLWhereLanguageDef.StormMainObjectKey));
                     colsPart = Query.Substring(Query.IndexOf(match.Value));
-                }
 
-                if (mustNewgenerate)
-                {
                     Query = "SELECT ";
                     if (customizationStruct.Distinct /*&& ForReadValues*/)
                     {

--- a/ICSSoft.STORMNET.FunctionalLanguage/SQLWhereLanguageDef.cs
+++ b/ICSSoft.STORMNET.FunctionalLanguage/SQLWhereLanguageDef.cs
@@ -32,7 +32,7 @@
         /// </summary>
         private const string TypeNameForIDataService = "ICSSoft.STORMNET.Business.IDataService, ICSSoft.STORMNET.Business, Version=1.0.0.1, Culture=neutral, PublicKeyToken=c17bb360f7843f45";
 
-        private static readonly Type IDataServiceType = Type.GetType(TypeNameForIDataService);
+        private static readonly Type DataServiceType = Type.GetType(TypeNameForIDataService);
 
         /// <summary>
         /// Конструктор по-умолчанию (CaseInsensitive берётся из конфига с флагом CaseInsensitive).
@@ -391,27 +391,30 @@
         /// <summary>
         /// Перенаправитель для обработки параметров: value is Function или value is VariableDef или это просто значение.
         /// </summary>
-        /// <param name="value"></param>
-        /// <param name="convertValue"></param>
-        /// <param name="convertIdentifier"></param>
-        /// <param name="dataService"></param>
+        /// <param name="value">Параметр для преобразования.</param>
+        /// <param name="convertValue">делегат для преобразования констант.</param>
+        /// <param name="convertIdentifier">делегат для преобразования идентификаторов.</param>
+        /// <param name="dataService">Сервис данных.</param>
         /// <returns></returns>
-        public virtual string SQLTranslSwitch(object value, delegateConvertValueToQueryValueString convertValue,
-            delegatePutIdentifierToBrackets convertIdentifier, object dataService = null)
+        public virtual string SQLTranslSwitch(
+            object value,
+            delegateConvertValueToQueryValueString convertValue,
+            delegatePutIdentifierToBrackets convertIdentifier,
+            object dataService = null)
         {
-            if (dataService != null && !IDataServiceType.IsAssignableFrom(dataService.GetType()))
+            if (dataService != null && !DataServiceType.IsInstanceOfType(dataService))
             {
                 throw new Exception("Параметр \"dataService\" не соответствует типу \"ICSSoft.STORMNET.Business.IDataService\"");
             }
 
-            if (value is Function)
+            if (value is Function function)
             {
-                return ((value as Function).FunctionDef.Language as SQLWhereLanguageDef).SQLTranslFunction(value as Function, convertValue, convertIdentifier, dataService);
+                return (function.FunctionDef.Language as SQLWhereLanguageDef).SQLTranslFunction(function, convertValue, convertIdentifier, dataService);
             }
 
-            if (value is VariableDef)
+            if (value is VariableDef vardef)
             {
-                if ((value as VariableDef).Language != null)
+                if (vardef.Language != null)
                 {
                     // if ((value as VariableDef).Type==SQLWhereLanguageDef.LanguageDef.BoolType)
                     //                  {
@@ -419,12 +422,12 @@
                     //                  }
                     //                  else
                     //                  {
-                    return ((value as VariableDef).Language as SQLWhereLanguageDef).SQLTranslVariable(value as VariableDef, convertValue, convertIdentifier);
+                    return (vardef.Language as SQLWhereLanguageDef).SQLTranslVariable(vardef, convertValue, convertIdentifier);
 
                     // }
                 }
 
-                return SQLTranslVariable(value as VariableDef, convertValue, convertIdentifier);
+                return SQLTranslVariable(vardef, convertValue, convertIdentifier);
             }
 
             return convertValue(value);
@@ -703,12 +706,13 @@
         /// <param name="convertIdentifier">делегат для преобразования идентификаторов.</param>
         /// <param name="dataService">Сервис данных.</param>
         /// <returns></returns>
-        public static string ToSQLString(Function function,
+        public static string ToSQLString(
+            Function function,
             delegateConvertValueToQueryValueString convertValue,
             delegatePutIdentifierToBrackets convertIdentifier,
             object dataService = null)
         {
-            if (dataService != null && !IDataServiceType.IsAssignableFrom(dataService.GetType()))
+            if (dataService != null && !DataServiceType.IsInstanceOfType(dataService))
             {
                 throw new Exception("Параметр \"dataService\" не соответствует типу \"ICSSoft.STORMNET.Business.IDataService\"");
             }


### PR DESCRIPTION
Before:
```
netcore
GenerateSQLSelectAgregatorPerformanceTest@MSSQLDataService: 7573 iterations
GenerateSQLSelectAgregatorPerformanceTest@PostgresDataService: 11563 iterations
GenerateSQLSelectAgregatorPerformanceTest@OracleDataService: 7281 iterations

netfx
GenerateSQLSelectAgregatorPerformanceTest@MSSQLDataService: 6911 iterations
GenerateSQLSelectAgregatorPerformanceTest@PostgresDataService: 9482 iterations
GenerateSQLSelectAgregatorPerformanceTest@OracleDataService: 6911 iterations
```

After:
```
netcore
GenerateSQLSelectAgregatorPerformanceTest@MSSQLDataService: 31983 iterations
GenerateSQLSelectAgregatorPerformanceTest@PostgresDataService: 16200 iterations
GenerateSQLSelectAgregatorPerformanceTest@OracleDataService: 24870 iterations

netfx
GenerateSQLSelectAgregatorPerformanceTest@MSSQLDataService: 28511 iterations
GenerateSQLSelectAgregatorPerformanceTest@PostgresDataService: 12924 iterations
GenerateSQLSelectAgregatorPerformanceTest@OracleDataService: 23501 iterations
```