### PR TITLE
Optimize LinqProvider.

### DIFF
--- a/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcs.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcs.cs
@@ -49,7 +49,8 @@
         public static LoadingCustomizationStruct GetLcs<Q>(Expression queryExpression, View view, IEnumerable<View> resolvingViews)
             where Q : IQueryModelVisitor
         {
-            var queryModel = UtilsLcs.CreateQueryParser().GetParsedQuery(queryExpression);
+            var queryParser = UtilsLcs.CreateQueryParser();
+            var queryModel = queryParser.GetParsedQuery(queryExpression);
             return GetQueryModelVisitor<Q>(false, view, resolvingViews).GenerateLcs(queryModel);
         }
 
@@ -59,7 +60,8 @@
         /// <param name="queryExpression">Linq-выражение, по которому будет сформирован <see cref="LoadingCustomizationStruct"/>.</param>
         /// <returns><see cref="LoadingCustomizationStruct"/>, полученный для указанного linq-выражения с динамически созданным представлением.</returns>
         public static LoadingCustomizationStruct GetLcs<T, Q>(Expression queryExpression)
-            where T : DataObject where Q : IQueryModelVisitor
+            where T : DataObject
+            where Q : IQueryModelVisitor
         {
             return GetLcs<Q>(queryExpression, typeof(T));
         }
@@ -73,7 +75,8 @@
         public static LoadingCustomizationStruct GetLcs<Q>(Expression queryExpression, Type type)
             where Q : IQueryModelVisitor
         {
-            var queryModel = UtilsLcs.CreateQueryParser().GetParsedQuery(queryExpression);
+            var queryParser = UtilsLcs.CreateQueryParser();
+            var queryModel = queryParser.GetParsedQuery(queryExpression);
 
             if (!type.IsSubclassOf(typeof(DataObject)))
             {

--- a/ICSSoft.STORMNET.Business.LINQProvider/UtilsLcs.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/UtilsLcs.cs
@@ -56,6 +56,8 @@
         private static HashSet<string> symbolsToEscape =
             new HashSet<string>() { "{", "}", "?", "+", "(", ")", "[", "]", "|", "^", "$", "." };
 
+        private static readonly Lazy<CompoundNodeTypeProvider> nodeTypeProvider = new Lazy<CompoundNodeTypeProvider>(ExpressionTreeParser.CreateDefaultNodeTypeProvider);
+
         #region Static Fields
 
         /// <summary>
@@ -109,11 +111,10 @@
         /// </returns>
         public static IQueryParser CreateQueryParser()
         {
-            CompoundNodeTypeProvider nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();
             var earlyTransformerRegistry = new ExpressionTransformerRegistry();
             earlyTransformerRegistry.Register(new DateTimeEarlyExpressionTransformer());
             CompoundExpressionTreeProcessor processor = CreateDefaultProcessor(earlyTransformerRegistry);
-            var expressionTreeParser = new ExpressionTreeParser(nodeTypeProvider, processor);
+            var expressionTreeParser = new ExpressionTreeParser(nodeTypeProvider.Value, processor);
             var queryParser = new QueryParser(expressionTreeParser);
             return queryParser;
         }


### PR DESCRIPTION
`ExpressionTreeParser.CreateDefaultNodeTypeProvider` очень дорогая операция, для odata-запроса на чтение занимает примерно 15-16% от всей "полезной" нагрузки в контроллере.