### PR TITLE
Fix catching and rethrowing a query exception

### DIFF
--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -5470,14 +5470,19 @@
             }
         }
 
-        protected virtual Exception RunCommands(StringCollection queries, StringCollection tables,
-            string table, System.Data.IDbCommand command,
-            object businessID, bool AlwaysThrowException)
+        protected virtual Exception RunCommands(
+            StringCollection queries,
+            StringCollection tables,
+            string table,
+            System.Data.IDbCommand command,
+            object businessID,
+            bool AlwaysThrowException)
         {
             int i = 0;
-            bool res = true;
+
+            // if exception is set then transaction is a broken state.
             Exception ex = null;
-            while (i < queries.Count)
+            while (i < queries.Count && ex == null)
             {
                 if (tables[i] == table)
                 {
@@ -5495,13 +5500,7 @@
                     catch (Exception exc)
                     {
                         i++;
-                        res = false;
                         ex = new ExecutingQueryException(query, string.Empty, exc);
-                        if (AlwaysThrowException)
-                        {
-                            BusinessTaskMonitor.EndSubTask(subTask);
-                            throw ex;
-                        }
                     }
 
                     BusinessTaskMonitor.EndSubTask(subTask);
@@ -5512,19 +5511,12 @@
                 }
             }
 
-            if (!res)
+            if (AlwaysThrowException && ex != null)
             {
-                if (AlwaysThrowException)
-                {
-                    throw ex;
-                }
+                throw ex;
+            }
 
-                return ex;
-            }
-            else
-            {
-                return null;
-            }
+            return ex;
         }
 
         protected OperationType Minus(OperationType ops, OperationType value)

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.Exceptions.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.Exceptions.cs
@@ -1,0 +1,59 @@
+﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests.Business
+{
+    using System;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.Business;
+
+    using NewPlatform.Flexberry.ORM.Tests;
+
+    using Xunit;
+
+    /// <summary>
+    /// Тесты обработки исключений хранилища.
+    /// </summary>
+    public partial class SQLDataServiceTest
+    {
+        /// <summary>
+        /// Тест проверяет, что <see cref="SQLDataService.RunCommands" />.
+        /// </summary>
+        [Fact]
+        public void RunCommandReturnsValidException()
+        {
+            foreach (IDataService dataService in DataServices)
+            {
+                // Arrange.
+                var bear = new Медведь { ПорядковыйНомер = 1, };
+                var lair0 = new Берлога
+                {
+                    Наименование = "LUXURY GOLD",
+                    Заброшена = true,
+                    ЛесРасположения = new Лес
+                    {
+                        Название = "Черняевский",
+                    },
+                };
+                var lair1 = new Берлога
+                {
+                    Наименование = "Дача с уточкой",
+                    ЛесРасположения = PKHelper.CreateDataObject<Лес>(Guid.NewGuid()), // объекта в БД нет, должен свалиться FK Constraint.
+                };
+                var lair2 = new Берлога
+                {
+                    Наименование = "Just in case",
+                    Заброшена = true,
+                    ЛесРасположения = new Лес
+                    {
+                        Название = "Шишкин",
+                    },
+                };
+                bear.Берлога.Add(lair0);
+                bear.Берлога.Add(lair1);
+                bear.Берлога.Add(lair2);
+
+                // Assert.
+                Assert.Throws<ExecutingQueryException>(() => dataService.UpdateObject(bear));
+            }
+        }
+    }
+}


### PR DESCRIPTION
No more `Npgsql.PostgresException: 25P02: current transaction is aborted, commands ignored until end of transaction block`