### PR TITLE
Temp fix for local build of project under .net6 and higher

### DIFF
--- a/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
+++ b/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
@@ -8,6 +8,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>
+	<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Для работы BinaryFormatter под более высокие версии дотнета добавлен флаг EnableUnsafeBinaryFormatterSerialization. 
Сформирована задача по замене данного форматтера на поддерживаемые (требуется оставить обратную совместимость).