### PR TITLE
Исправление редкой ошибки с нехранимыми свойствами и наследованием

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+1. Error on loading with not stored attribute with inheritance.
 
 ### Security
 

--- a/ICSSoft.STORMNET.DataObject/Information.cs
+++ b/ICSSoft.STORMNET.DataObject/Information.cs
@@ -313,7 +313,7 @@
                         propType = Nullable.GetUnderlyingType(propType);
                     }
 
-                    SetHandler setHandler = GetSetHandler(tp, pi);
+                    SetHandler setHandler = GetSetHandler(tp, pi, true);
 
                     if (propType == typeof(string))
                     {
@@ -467,8 +467,9 @@
         /// </summary>
         /// <param name="type">Тип данных.</param>
         /// <param name="propInfo">Метаданные о свойстве.</param>
+        /// <param name="piCheck">Флаг, определяющий, что следует производить проверку возможности создания <see cref="SetHandler"/> перед созданием.</param>
         /// <returns>Делегат.</returns>
-        internal static SetHandler GetSetHandler(Type type, PropertyInfo propInfo)
+        internal static SetHandler GetSetHandler(Type type, PropertyInfo propInfo, bool piCheck = false)
         {
             if (type == null)
             {
@@ -481,7 +482,11 @@
             }
 
             long key = (type.GetHashCode() * 10000000000) + propInfo.Name.GetHashCode();
-            return cacheSetPropValueByName.GetOrAdd(key, k => DynamicMethodCompiler.CreateSetHandler(type, propInfo));
+            return cacheSetPropValueByName.GetOrAdd(
+                key,
+                k => {
+                        return (!piCheck || propInfo.CanWrite) ? DynamicMethodCompiler.CreateSetHandler(type, propInfo) : null;
+                    });
         }
 
         /// <summary>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotStoredPropertyLoadingTests.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotStoredPropertyLoadingTests.cs
@@ -118,5 +118,30 @@
                 }
             }
         }
+
+        /// <summary>
+        /// Выполняется тестирование работы с нехранимым классом при наследовании.
+        /// </summary>
+        [Fact]
+        public void NotStoredTest()
+        {
+            foreach (IDataService dataService in DataServices)
+            {
+                Tests.Cabbage2 cabbage = new Tests.Cabbage2 { Name = "Test" + DateTime.Now.ToString() };
+                var objsToUpdate = new DataObject[] { cabbage };
+                dataService.UpdateObjects(ref objsToUpdate, new DataObjectCache(), true);
+                View view = new View()
+                {
+                    DefineClassType = typeof(Tests.Cabbage2),
+                    Properties = new PropertyInView[] { new PropertyInView("AssocType", string.Empty, true, string.Empty) },
+                };
+                LoadingCustomizationStruct lcs = LoadingCustomizationStruct.GetSimpleStruct(typeof(Tests.Cabbage2), view);
+                int count;
+
+                DataObject[] result = dataService.LoadObjects(lcs);
+                Assert.NotNull(result);
+                Assert.Equal(1, result.Length);
+            }
+        }
     }
 }

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM package.</description>
     <releaseNotes>
-      Added
-      1. 
+      Changed
+      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>7.1.0</version>
+    <version>7.1.1-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,16 +13,16 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Added
-      1. Add asyncronous DataService interface.
+      1. 
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.0" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1-beta01" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.0" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1-beta01" />
         <dependency id="System.Data.SqlClient" version="4.6.1" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM package.</description>
     <releaseNotes>
-      Added
-      1. 
+      Changed
+      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>7.1.0</version>
+    <version>7.1.1-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,17 +13,17 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Added
-      1. Add asyncronous DataService interface.
+      1. 
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.0" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1-beta01" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.0" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1-beta01" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>7.1.0</version>
+    <version>7.1.1-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,7 +13,7 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Added
-      1. Add asyncronous DataService interface.
+      1. 
 	  
 	  Changed
       1. Upgraded Npgsql version to 3.2.7 (PostgreSQL 14+ support).
@@ -21,7 +21,7 @@
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
-      <dependency id="NewPlatform.Flexberry.ORM" version="7.1.0" />
+      <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1-beta01" />
       <dependency id="Npgsql" version="3.2.7" />
     </dependencies>
   </metadata>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -12,11 +12,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM package.</description>
     <releaseNotes>
-      Added
-      1. 
-	  
-	  Changed
-      1. Upgraded Npgsql version to 3.2.7 (PostgreSQL 14+ support).
+      Changed
+      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>

--- a/NewPlatform.Flexberry.ORM.Test.Objects/Cabbage2.cs
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/Cabbage2.cs
@@ -42,12 +42,22 @@ namespace NewPlatform.Flexberry.ORM.Tests
         private string fType;
         
         private NewPlatform.Flexberry.ORM.Tests.DetailArrayOfCabbagePart2 fCabbageParts;
-        
+
         // *** Start programmer edit section *** (Cabbage2 CustomMembers)
+
+        [NotStored]
+        [DataServiceExpression(typeof(ICSSoft.STORMNET.Business.PostgresDataService), "'Association'")]
+        public override string AssocType
+        {
+            get
+            {
+                return base.AssocType;
+            }
+        }
 
         // *** End programmer edit section *** (Cabbage2 CustomMembers)
 
-        
+
         /// <summary>
         /// Type.
         /// </summary>

--- a/NewPlatform.Flexberry.ORM.Test.Objects/Plant2.cs
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/Plant2.cs
@@ -36,12 +36,21 @@ namespace NewPlatform.Flexberry.ORM.Tests
     {
         
         private string fName;
-        
+
         // *** Start programmer edit section *** (Plant2 CustomMembers)
+
+        [NotStored]
+        public virtual string AssocType
+        {
+            get
+            {
+                return GetType().Name;
+            }
+        }
 
         // *** End programmer edit section *** (Plant2 CustomMembers)
 
-        
+
         /// <summary>
         /// Name.
         /// </summary>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>7.1.0</version>
+    <version>7.1.1-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM package.</description>
     <releaseNotes>
-      Added
-      1. Add asyncronous DataService interface.
+      Fixed
+      1. Error on loading with not stored attribute with inheritance.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>


### PR DESCRIPTION
Ранее при рефакторинге https://github.com/Flexberry/NewPlatform.Flexberry.ORM/commit/4a08740082f68831aeca860c1321bb09018fb357 была допущена ошибка, когда изредка выполняющееся условие на PropertyInView.CanWrite, защищающее от ошибки, было пропущено.

Тест реализован без генерации, поскольку генерируемый код выглядит несколько иначе (принципиально отсутствие set-метода, такие варианты встречаются в старом коде).