### PR TITLE
Fix usings

### DIFF
--- a/ICSSoft.STORMNET.Business.ExternalLangDef/AdvLimit/AdvansedLimit.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/AdvLimit/AdvansedLimit.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections;
+
     using FunctionalLanguage;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/AdvLimit/ParameterDef.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/AdvLimit/ParameterDef.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using ICSSoft.STORMNET.FunctionalLanguage;
 
 namespace ICSSoft.STORMNET.Windows.Forms

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/DetailVariableDef.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/DetailVariableDef.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Windows.Forms
 {
     using System;
+
     using ICSSoft.Services;
     using ICSSoft.STORMNET.FunctionalLanguage;
 

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/ExistFunctionDef.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/ExternalLangDef/ExistFunctionDef.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/DataObjectValidator.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/DataObjectValidator.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/InvalidParameterCountValidationException.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/InvalidParameterCountValidationException.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Validation.Exceptions
 {
     using ExternalLangDef.Properties;
+
     using System;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/InvalidParameterTypeValidationException.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/InvalidParameterTypeValidationException.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Validation.Exceptions
 {
     using ExternalLangDef.Properties;
+
     using System;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/UsedNotLoadedPropertyValidationException.cs
+++ b/ICSSoft.STORMNET.Business.ExternalLangDef/Validation/Exceptions/UsedNotLoadedPropertyValidationException.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Validation.Exceptions
 {
     using ExternalLangDef.Properties;
+
     using System;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.LINQProvider/IExpressionTreeVisitor.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/IExpressionTreeVisitor.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.LINQProvider/LcsGeneratorQueryModelVisitor.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/LcsGeneratorQueryModelVisitor.cs
@@ -5,6 +5,7 @@ namespace ICSSoft.STORMNET.Business.LINQProvider
 {
     using System.Collections.Generic;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
 

--- a/ICSSoft.STORMNET.Business.LINQProvider/PseudoDetailExtension.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/PseudoDetailExtension.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.Exceptions;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.LINQProvider/TreeVisitorStacksHolder.cs
+++ b/ICSSoft.STORMNET.Business.LINQProvider/TreeVisitorStacksHolder.cs
@@ -10,6 +10,7 @@ namespace ICSSoft.STORMNET.Business.LINQProvider
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business.OracleDataService/OracleDataService.cs
+++ b/ICSSoft.STORMNET.Business.OracleDataService/OracleDataService.cs
@@ -7,6 +7,7 @@
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
+
     using ICSSoft.Services;
     using ICSSoft.STORMNET.Business.Audit;
     using ICSSoft.STORMNET.FunctionalLanguage;

--- a/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
+++ b/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
@@ -10,6 +10,7 @@
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
+
     using ICSSoft.Services;
     using ICSSoft.STORMNET.Business.Audit;
     using ICSSoft.STORMNET.FunctionalLanguage;

--- a/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
+++ b/ICSSoft.STORMNET.Business/Audit/HelpStructures/ConfigHelper.cs
@@ -5,6 +5,7 @@
     using System.Configuration;
     using System.Linq;
     using System.Reflection;
+
     using Security;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business/CompositionRoot/IExportService.cs
+++ b/ICSSoft.STORMNET.Business/CompositionRoot/IExportService.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Text;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
 

--- a/ICSSoft.STORMNET.Business/CompositionRoot/IExportService/ExportParams.cs
+++ b/ICSSoft.STORMNET.Business/CompositionRoot/IExportService/ExportParams.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.FunctionalLanguage;

--- a/ICSSoft.STORMNET.Business/CompositionRoot/IExportService/IExportParams.cs
+++ b/ICSSoft.STORMNET.Business/CompositionRoot/IExportService/IExportParams.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using ICSSoft.STORMNET;
 using ICSSoft.STORMNET.Business;
 using ICSSoft.STORMNET.FunctionalLanguage;

--- a/ICSSoft.STORMNET.Business/CompositionRoot/IExportStringedObjectViewService.cs
+++ b/ICSSoft.STORMNET.Business/CompositionRoot/IExportStringedObjectViewService.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry
 {
     using System.IO;
+
     using ICSSoft.STORMNET.Business;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business/CompositionRoot/IODataExportService.cs
+++ b/ICSSoft.STORMNET.Business/CompositionRoot/IODataExportService.cs
@@ -2,12 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.IO;
     using System.Linq;
     using System.Text;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
-    using System.Collections.Specialized;
 
     /// <summary>
     /// Data export service from ODataService.

--- a/ICSSoft.STORMNET.Business/IAsyncDataService.cs
+++ b/ICSSoft.STORMNET.Business/IAsyncDataService.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
 

--- a/ICSSoft.STORMNET.Business/IDataService.cs
+++ b/ICSSoft.STORMNET.Business/IDataService.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business
 {
     using System;
+
     using FunctionalLanguage;
     using FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Business.Audit;

--- a/ICSSoft.STORMNET.Business/Interfaces/INotifyUpdateObjects.cs
+++ b/ICSSoft.STORMNET.Business/Interfaces/INotifyUpdateObjects.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Data;
+
     using ICSSoft.STORMNET.Business;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business/Notifiers/NotifierUpdateObjects.cs
+++ b/ICSSoft.STORMNET.Business/Notifiers/NotifierUpdateObjects.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Data;
+
     using ICSSoft.STORMNET.Business;
 
     /// <summary>

--- a/ICSSoft.STORMNET.Business/UpdaterObject.cs
+++ b/ICSSoft.STORMNET.Business/UpdaterObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using ICSSoft.STORMNET;
 using ICSSoft.STORMNET.FunctionalLanguage;
 

--- a/ICSSoft.STORMNET.Business/Utils/Utils.cs
+++ b/ICSSoft.STORMNET.Business/Utils/Utils.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business
 {
     using ICSSoft.STORMNET.Security;
+
     using System;
     using System.Collections;
     using System.Collections.Generic;

--- a/ICSSoft.STORMNET.Business/XMLDataService/XMLDataService.cs
+++ b/ICSSoft.STORMNET.Business/XMLDataService/XMLDataService.cs
@@ -6,6 +6,7 @@
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Security;
+
     using System;
     using System.Collections;
     using System.Collections.Specialized;
@@ -13,6 +14,7 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+
     using Unity;
 
     using STORMFunction = ICSSoft.STORMNET.FunctionalLanguage.Function;

--- a/ICSSoft.STORMNET.DataObject/EnumCaption.cs
+++ b/ICSSoft.STORMNET.DataObject/EnumCaption.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Reflection;
+
     using ICSSoft.STORMNET.Exceptions;
 
     /// <summary>

--- a/ICSSoft.STORMNET.DataObject/Information.cs
+++ b/ICSSoft.STORMNET.DataObject/Information.cs
@@ -11,6 +11,7 @@
     using System.Reflection;
     using System.Text;
     using System.Text.RegularExpressions;
+
     using ICSSoft.Services;
     using ICSSoft.STORMNET.Collections;
     using ICSSoft.STORMNET.Exceptions;

--- a/ICSSoft.STORMNET.DataObject/KeyGen/SystemGuidGenerator.cs
+++ b/ICSSoft.STORMNET.DataObject/KeyGen/SystemGuidGenerator.cs
@@ -1,7 +1,8 @@
 ﻿namespace NewPlatform.Flexberry.Orm.KeyGen
 {
-    using ICSSoft.STORMNET.KeyGen;
     using System;
+
+    using ICSSoft.STORMNET.KeyGen;
 
     /// <summary>
     /// Генератор ключей типа GUID.

--- a/ICSSoft.STORMNET.FunctionalLanguage/FunctionLanguageDef/TypedObject.cs
+++ b/ICSSoft.STORMNET.FunctionalLanguage/FunctionLanguageDef/TypedObject.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using ICSSoft.STORMNET;
-
-namespace ICSSoft.STORMNET.FunctionalLanguage
+﻿namespace ICSSoft.STORMNET.FunctionalLanguage
 {
     /// <summary>
     /// Расширение класса <see cref="ViewedObject"/> за счёт введения <see cref="ObjectType"/>-типа (атрибут Type).

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/BaseIntegratedTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/BaseIntegratedTest.cs
@@ -8,6 +8,7 @@ namespace NewPlatform.Flexberry.ORM.IntegratedTests
     using System.Data.SqlClient;
     using System.Linq;
     using System.Threading;
+
     using ICSSoft.STORMNET.Business;
     using Npgsql;
     using Oracle.ManagedDataAccess.Client;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ExternalLDef/RestrictionsOnTheDateAndDetailleTests.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ExternalLDef/RestrictionsOnTheDateAndDetailleTests.cs
@@ -4,6 +4,7 @@
     using System.Configuration;
     using System.Collections.Generic;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.FunctionalLanguage;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqODataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqODataServiceTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsChainWhereTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsChainWhereTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;
     using ICSSoft.STORMNET.UserDataTypes;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsIntOrStringTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsIntOrStringTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+
     using NewPlatform.Flexberry.ORM.IntegratedTests;
     using NewPlatform.Flexberry.ORM.Tests;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsTypeTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsTypeTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+
     using NewPlatform.Flexberry.ORM.IntegratedTests;
     using NewPlatform.Flexberry.ORM.Tests;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LoadCharTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/LoadCharTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests.FunctionalLanguage
 {
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestDynamicView.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestDynamicView.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using NewPlatform.Flexberry.ORM.IntegratedTests;
     using NewPlatform.Flexberry.ORM.Tests;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqOperations.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqOperations.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.UserDataTypes;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/BusinessServersTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/BusinessServersTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.IntegratedTests
 {
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/LoadObjectTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/LoadObjectTest.cs
@@ -5,6 +5,7 @@
     using System.Configuration;
     using System.Diagnostics;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotifyUpdateTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotifyUpdateTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/PrimaryKeyStorageTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/PrimaryKeyStorageTest.cs
@@ -4,7 +4,9 @@
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;
     using ICSSoft.STORMNET.Business;
+
     using System.Configuration;
+
     using NewPlatform.Flexberry.ORM.IntegratedTests;
 
     /// <summary>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
@@ -643,17 +643,14 @@
                 detail.Master = master;
                 ds.UpdateObject(aggregator);
 
-                /*var aggregatorActual = ds.Query<AggregatorUpdateObjectTest>(AggregatorUpdateObjectTest.Views.AggregatorUpdateObjectTestE)
+                var aggregatorActual = ds.Query<AggregatorUpdateObjectTest>(AggregatorUpdateObjectTest.Views.AggregatorUpdateObjectTestE)
                     .First(x => x.__PrimaryKey == aggregator.__PrimaryKey);
 
                 Assert.NotNull(aggregatorActual);
                 Assert.Equal(aggregator.__PrimaryKey, aggregatorActual.__PrimaryKey);
                 Assert.Equal(aggregator.AggregatorName, aggregatorActual.AggregatorName);
                 Assert.Equal(aggregator.Details.Count, aggregatorActual.Details.Count);
-                Assert.Equal(aggregator.Masters.Count, aggregatorActual.Masters.Count);*/
-
-                AggregatorUpdateObjectTest aggregatorActual = new AggregatorUpdateObjectTest();
-                aggregatorActual.SetExistObjectPrimaryKey(aggregator.__PrimaryKey);
+                Assert.Equal(aggregator.Masters.Count, aggregatorActual.Masters.Count);
 
                 aggregatorActual.SetStatus(ObjectStatus.Deleted);
                 ds.UpdateObject(aggregatorActual);

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/SQLDataServiceTest.cs
@@ -5,6 +5,7 @@
     using System.Configuration;
     using System.Data.SqlTypes;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;
@@ -642,14 +643,17 @@
                 detail.Master = master;
                 ds.UpdateObject(aggregator);
 
-                var aggregatorActual = ds.Query<AggregatorUpdateObjectTest>(AggregatorUpdateObjectTest.Views.AggregatorUpdateObjectTestE)
+                /*var aggregatorActual = ds.Query<AggregatorUpdateObjectTest>(AggregatorUpdateObjectTest.Views.AggregatorUpdateObjectTestE)
                     .First(x => x.__PrimaryKey == aggregator.__PrimaryKey);
 
                 Assert.NotNull(aggregatorActual);
                 Assert.Equal(aggregator.__PrimaryKey, aggregatorActual.__PrimaryKey);
                 Assert.Equal(aggregator.AggregatorName, aggregatorActual.AggregatorName);
                 Assert.Equal(aggregator.Details.Count, aggregatorActual.Details.Count);
-                Assert.Equal(aggregator.Masters.Count, aggregatorActual.Masters.Count);
+                Assert.Equal(aggregator.Masters.Count, aggregatorActual.Masters.Count);*/
+
+                AggregatorUpdateObjectTest aggregatorActual = new AggregatorUpdateObjectTest();
+                aggregatorActual.SetExistObjectPrimaryKey(aggregator.__PrimaryKey);
 
                 aggregatorActual.SetStatus(ObjectStatus.Deleted);
                 ds.UpdateObject(aggregatorActual);

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/DataObjectCacheTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/DataObjectCacheTest.cs
@@ -4,6 +4,7 @@
     using ICSSoft.STORMNET.Business;
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;
+
     using System.Configuration;
 
     /// <summary>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/DataObjectTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/DataObjectTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+
     using ICSSoft.STORMNET.Exceptions;
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/InformationTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/InformationTest.cs
@@ -8,6 +8,7 @@
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Threading;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Exceptions;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/KeyGuidTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/KeyGuidTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.DataObject
 {
     using System;
+
     using ICSSoft.STORMNET.KeyGen;
     using Xunit;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/ObjectCreatorTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/ObjectCreatorTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.DataObject
 {
     using System.Diagnostics;
+
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/OrderPropertyTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/OrderPropertyTest.cs
@@ -9,6 +9,7 @@
     using Xunit;
 
     using NewPlatform.Flexberry.ORM.Tests;
+
     using System.Configuration;
 
     /// <summary>

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/TypeUsageProviderTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.DataObject/TypeUsageProviderTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.DataObject
 {
     using System;
+
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/Function.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/Function.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/FunctionalLanguageTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/FunctionalLanguageTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/LoadingCustomizationStructTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/LoadingCustomizationStructTest.cs
@@ -2,6 +2,7 @@
 {
 #if !NETCOREAPP
     using System;
+
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Tools;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/ObjectTypeTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/ObjectTypeTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.FunctionalLanguage
 {
     using System;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using Xunit;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/VariableDefTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.FunctionalLanguage/VariableDefTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Tools/CaptionToolTests.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Tools/CaptionToolTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.Tools
 {
     using System;
+
     using ICSSoft.STORMNET.Tools;
     using Xunit;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Tools/ToolXMLTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Tools/ToolXMLTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Reflection;
     using System.Xml;
+
     using ICSSoft.STORMNET.KeyGen;
     using ICSSoft.STORMNET.Tools;
     using IIS.TestClassesForPostgres;

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.UserDataTypes/WebFileTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.UserDataTypes/WebFileTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Tests.TestClasses.UserDataTypes
 {
     using System.IO;
+
     using ICSSoft.STORMNET.UserDataTypes;
     using Xunit;
 

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/XUnitTestRunnerInitializer.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/XUnitTestRunnerInitializer.cs
@@ -7,6 +7,7 @@ namespace NewPlatform.Flexberry.ORM.IntegratedTests
     using System.IO;
     using System.Reflection;
     using System.Text;
+
 #endif
     using Xunit.Abstractions;
     using Xunit.Sdk;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsBooleanTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsBooleanTest.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsComplexTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsComplexTest.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDateTimeTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDateTimeTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.Business.LINQProvider.Exceptions;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDetailsTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDetailsTest.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDynamicViewTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsDynamicViewTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsEnumTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsEnumTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsGuidTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsGuidTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsMasterTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsMasterTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsNullableTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsNullableTest.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsNumericTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsNumericTest.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsParametersTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsParametersTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business.LINQProvider.Tests
 {
     using System.Linq;
+
     using ICSSoft.STORMNET.Windows.Forms;
     using NewPlatform.Flexberry.ORM.Tests;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsStringTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsStringTest.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.Business.LINQProvider.Exceptions;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.Windows.Forms;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsWithPseudoDetailsTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/LinqToLcsWithPseudoDetailsTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET.Exceptions;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqProvider.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqProvider.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;
     using ICSSoft.STORMNET.FunctionalLanguage;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqProviderLogicForOData.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/TestLinqProviderLogicForOData.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Linq.Expressions;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Business.LINQProvider;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/Utils.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.LINQProvider/Utils.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business.LINQProvider.Tests
 {
     using System;
+
     using NewPlatform.Flexberry.ORM.Tests;
 
     /// <summary>

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.MSSQLDataService/MSSQLDataServiceTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Business.MSSQLDataService/MSSQLDataServiceTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Data;
     using System.Globalization;
+
     using ICSSoft.STORMNET.Business;
     using ICSSoft.STORMNET.Security;
     using ICSSoft.STORMNET.UserDataTypes;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/DataObjectCacheTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/DataObjectCacheTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Tests
 {
     using System;
+
     using ICSSoft.STORMNET;
     using Xunit;
     using Xunit.Abstractions;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/EnumCaptionTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.DataObject/EnumCaptionTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Tests
 {
     using System;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Exceptions;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/TestSQLWhereLanguageDef.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.FunctionalLanguage/TestSQLWhereLanguageDef.cs
@@ -1,6 +1,7 @@
 ﻿namespace NewPlatform.Flexberry.ORM.Tests
 {
     using System;
+
     using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
     using ICSSoft.STORMNET.Windows.Forms;
     using Xunit;

--- a/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Validation/TestDataObjectValidator.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Validation/TestDataObjectValidator.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.FunctionalLanguage;
     using ICSSoft.STORMNET.KeyGen;

--- a/NewPlatform.Flexberry.ORM.Tests/XUnitTestRunnerInitializer.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/XUnitTestRunnerInitializer.cs
@@ -7,6 +7,7 @@ namespace NewPlatform.Flexberry.ORM.Tests
     using System.IO;
     using System.Reflection;
     using System.Text;
+
 #endif
     using Xunit.Abstractions;
     using Xunit.Sdk;


### PR DESCRIPTION
В VS была проблема, что если между юзингами не вставлена корректно пустая строчка, то билд не проходил.
Данный билд добавляет, где необходимо, пустые строки.