### PR TITLE
Коррекция порядка обработки свойств для объекта с детейлом и мастером одного типа

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+1. Fixed order of property processing for objects with details and masters of the same type.
 
 ### Security
 

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -4171,7 +4171,7 @@
             ObjectStatus? objectStatus = currentObject?.GetStatus();
 
             // Смотрим мастера и детейлы для выявления зависимостей.
-            // Порядок важен. Сначала мастера, потом детейлы.
+            // Порядок важен. Сначала детейлы, потом мастера.
             List<string> details = new List<string>();
             Dictionary<string, Type> masters = new Dictionary<string, Type>();
             foreach (string prop in props)

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>7.1.1</version>
+    <version>7.2.0-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,18 +13,18 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Fixed
-      1. Error on loading with not stored attribute with inheritance.
+      1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
         <dependency id="System.Data.SqlClient" version="4.6.1" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>7.1.1</version>
+    <version>7.2.0-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,19 +13,19 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Fixed
-      1. Error on loading with not stored attribute with inheritance.
+      1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>7.1.1</version>
+    <version>7.2.0-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,14 +13,14 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Fixed
-      1. Error on loading with not stored attribute with inheritance.
+      1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.1.1.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
-      <dependency id="NewPlatform.Flexberry.ORM" version="7.1.1" />
+      <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
       <dependency id="Npgsql" version="3.2.7" />
     </dependencies>
   </metadata>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>7.1.1</version>
+    <version>7.2.0-beta01</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,7 +13,7 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Fixed
-      1. Error on loading with not stored attribute with inheritance.
+      1. Fixed order of property processing for objects with details and masters of the same type.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM</tags>


### PR DESCRIPTION
В общем случае, если у объекта детейл и мастер были одного типа, то порядок обработки этих свойств был определён порядком расположения их в классе. Теперь же зафиксировано, что сначала обрабатываются детейлы, а потом мастера (в противном случае порядок объектов разрешается некорректно).