### PR TITLE
Update version of Flexberry ORM up to 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,29 @@
 # Flexberry ORM Changelog
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
-
 ## [Unreleased]
 
 ### Added
 
 ### Changed
-1. Upgrade NewPlatform.Flexberry.LogService up to 2.2.1.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-1. Fixed order of property processing for objects with details and masters of the same type.
 
 ### Security
 
 ### Performance
+
+## [7.2.0] - 2024-03-20
+
+### Changed
+1. Upgrade NewPlatform.Flexberry.LogService up to 2.2.1.
+
+### Fixed
+1. Fixed order of property processing for objects with details and masters of the same type.
 
 ## [7.1.1] - 2023-06-08
 

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>7.2.0-beta01</version>
+    <version>7.2.0</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -15,16 +15,16 @@
       Fixed
       1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2023</copyright>
+    <copyright>Copyright New Platform Ltd 2024</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="System.Data.SqlClient" version="4.6.1" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>7.2.0-beta01</version>
+    <version>7.2.0</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -15,17 +15,17 @@
       Fixed
       1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2023</copyright>
+    <copyright>Copyright New Platform Ltd 2024</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>7.2.0-beta01</version>
+    <version>7.2.0</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -15,12 +15,12 @@
       Fixed
       1. Fixed order of property processing for objects with details and masters of the same type.
       Changed
-      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0-beta01.
+      1. Updated NewPlatform.Flexberry.ORM up to 7.2.0.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2023</copyright>
+    <copyright>Copyright New Platform Ltd 2024</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
-      <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+      <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
       <dependency id="Npgsql" version="3.2.7" />
     </dependencies>
   </metadata>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>7.2.0-beta01</version>
+    <version>7.2.0</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -13,12 +13,12 @@
     <description>Flexberry ORM package.</description>
     <releaseNotes>
       Changed
-      1. Upgrade NewPlatform.Flexberry.LogServic up to 2.2.1.
+      1. Upgrade NewPlatform.Flexberry.LogService up to 2.2.1.
 
       Fixed
       1. Fixed order of property processing for objects with details and masters of the same type.
     </releaseNotes>
-    <copyright>Copyright New Platform Ltd 2023</copyright>
+    <copyright>Copyright New Platform Ltd 2024</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">


### PR DESCRIPTION
## [7.2.0] - 2024-03-20

### Changed
1. Upgrade NewPlatform.Flexberry.LogService up to 2.2.1.

### Fixed
1. Fixed order of property processing for objects with details and masters of the same type.