### PR TITLE
Fixed possible IDataReader existing after connection closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ DetailVariableDef.ViewGenerator = null; // or resolving of interface IViewGenera
 8. Constructor of class `AuditService`.
 9. Constructor of class `BusinessServerProvider`.
 
-
 ### Deprecated
 1. `ExternalLangDef.LanguageDef` (correct way is creation of new instance of `ExternalLangDef` with proper DataService).
 2. `UnityFactory`.
@@ -49,6 +48,7 @@ DetailVariableDef.ViewGenerator = null; // or resolving of interface IViewGenera
 12. Getting of `CommandTimeout` throught configuration file.
 
 ### Fixed
+1. Disposing of `IDataReader` during data loading at `SQLDataService`.
 
 ### Security
 

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -1862,10 +1862,11 @@
                     myCommand.CommandText = query;
                     myCommand.Transaction = transaction;
                     CustomizeCommand(myCommand);
-
-                    IDataReader myReader = myCommand.ExecuteReader();
-                    state = new object[] { connection, myReader };
-                    return ReadNextByExtConn(ref state, loadingBufferSize);
+                    using (IDataReader myReader = myCommand.ExecuteReader())
+                    {
+                        state = new object[] { connection, myReader };
+                        return ReadNextByExtConn(ref state, loadingBufferSize);
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
В тестах в проекте [NewPlatform.Flexberry.ORM.ODataService](https://github.com/Flexberry/NewPlatform.Flexberry.ORM.ODataService) возникли проблемы с работой тестов под .Net 8 в MS SQL Server.

Ошибка указала на 

System.InvalidOperationException: There is already an open DataReader associated with this Command which must be closed first.
    at System.Data.SqlClient.SqlInternalConnectionTds.ValidateConnectionForExecute(SqlCommand command)
    at System.Data.SqlClient.SqlInternalTransaction.Rollback()
    at System.Data.SqlClient.SqlInternalTransaction.Dispose(Boolean disposing)
    at System.Data.SqlClient.SqlInternalTransaction.Dispose()
    at System.Data.SqlClient.SqlTransaction.Dispose(Boolean disposing)
    at ICSSoft.STORMNET.Business.DbTransactionWrapper.Dispose()
    at ICSSoft.STORMNET.Business.SQLDataService.LoadObjects(LoadingCustomizationStruct customizationStruct, Object& state, DataObjectCache dataObjectCache).
    
 В ходе исследования фрагмента кода было выявлено, что в методе действительно формируется IDataReader, который потенциально может быть не закрыт. Добавлено закрытие.
