### PR TITLE
Сформирована версия 8-0-0-beta05

### DIFF
--- a/ICSSoft.STORMNET.Tools/ICSSoft.STORMNET.Tools.csproj
+++ b/ICSSoft.STORMNET.Tools/ICSSoft.STORMNET.Tools.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
   </ItemGroup>
 
+<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+	<PackageReference Include="System.Runtime.Serialization.Formatters" Version="10.0.0" />
+</ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\ICSSoft.STORMNET.Collections\ICSSoft.STORMNET.Collections.csproj" />
     <ProjectReference Include="..\ICSSoft.STORMNET.DataObject\ICSSoft.STORMNET.DataObject.csproj" />

--- a/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
+++ b/ICSSoft.STORMNET.UserDataTypes/ICSSoft.STORMNET.UserDataTypes.csproj
@@ -11,6 +11,10 @@
 		<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
 	</PropertyGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<PackageReference Include="System.Runtime.Serialization.Formatters" Version="10.0.0" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\ICSSoft.STORMNET.Business\ICSSoft.STORMNET.Business.csproj" />
 		<ProjectReference Include="..\ICSSoft.STORMNET.Collections\ICSSoft.STORMNET.Collections.csproj" />

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/NewPlatform.Flexberry.ORM.IntegratedTests.csproj
@@ -20,10 +20,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-	<PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'  Or '$(TargetFramework)' == 'net7.0'">
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>8.0.0-beta04</version>
+    <version>8.0.0-beta05</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,36 +18,36 @@
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta04`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta05`.
 		4. Version of `Microsoft.Data.SqlClient` changed to `6.1.3`.
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2025</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
       </group>
 		<group targetFramework=".NETFramework4.6.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 		</group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 		  <dependency id="System.Data.SqlClient" version="4.9.0" />
       </group>
 		<group targetFramework=".NETCoreApp3.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="System.Data.SqlClient" version="4.9.0" />
 		</group>
 		<group targetFramework="net6.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="System.Data.SqlClient" version="4.9.0" />
 		</group>
 		<group targetFramework="net7.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="System.Data.SqlClient" version="4.9.0" />
 		</group>
 		<group targetFramework="net10.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Microsoft.Data.SqlClient" version="6.1.3" />
 		</group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>8.0.0-beta04</version>
+    <version>8.0.0-beta05</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,37 +18,37 @@
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta04`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta05`.
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2025</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
 		<group targetFramework=".NETFramework4.6.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
 		</group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
 		<group targetFramework=".NETCoreApp3.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
 		<group targetFramework="net6.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
 		<group targetFramework="net7.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
 		<group targetFramework="net10.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>8.0.0-beta04</version>
+    <version>8.0.0-beta05</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,38 +18,38 @@
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta04`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta05`.
 		4. Version of `Npgsql` changed to `4.0.17` for `.NETFramework4.5` and to `5.0.18` for `.NETStandard2.0` and upper.
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2025</copyright>
     <tags>Flexberry ORM</tags>
 	  <dependencies>
 		  <group targetFramework=".NETFramework4.5">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="4.0.17" />
 		  </group>
 		  <group targetFramework=".NETFramework4.6.1">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="4.0.17" />
 		  </group>
 		  <group targetFramework=".NETStandard2.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework=".NETCoreApp3.1">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net6.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net7.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net10.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta04" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta05" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 	  </dependencies>

--- a/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Tools/ToolBinarySerializerTest.cs
+++ b/NewPlatform.Flexberry.ORM.Tests/ICSSoft.STORMNET.Tools/ToolBinarySerializerTest.cs
@@ -1,0 +1,33 @@
+﻿namespace NewPlatform.Flexberry.ORM.Tests
+{
+    using System;
+    using System.Runtime.Serialization.Formatters.Binary;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.FunctionalLanguage;
+    using ICSSoft.STORMNET.FunctionalLanguage.SQLWhere;
+    using ICSSoft.STORMNET.Tools;
+    using Xunit;
+
+    /// <summary>
+    /// Тесты для <see cref="ToolBinarySerializer"/>.
+    /// </summary>
+    public class ToolBinarySerializerTest
+    {
+        /// <summary>
+        /// Проверка, что <see cref="BinaryFormatter"/> корректно отрабатывает под разными дотнетами.
+        /// Класс помечен obsolete, поэтому требуются разные ухищрения для запуска.
+        /// </summary>
+        [Fact]
+        public void TestCorrectBinaryFormatterWork()
+        {
+            Guid testGuid = Guid.NewGuid();
+            SQLWhereLanguageDef languageDef = SQLWhereLanguageDef.LanguageDef;
+            Function limitFunction = languageDef.GetFunction(languageDef.funcEQ, new VariableDef(languageDef.GuidType, Information.ExtractPropertyPath<DataObject>(x => x.__PrimaryKey)), testGuid);
+            object pseudoserializedFunction = languageDef.FunctionToSimpleStruct(limitFunction);
+            string filterString = ToolBinarySerializer.ObjectToString(pseudoserializedFunction);
+
+            Assert.NotNull(filterString);
+        }
+    }
+}

--- a/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
+++ b/NewPlatform.Flexberry.ORM.Tests/NewPlatform.Flexberry.ORM.Tests.csproj
@@ -8,6 +8,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+	<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>8.0.0-beta04</version>
+    <version>8.0.0-beta05</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -131,6 +131,7 @@
 			<dependency id="Unity.Configuration" version="5.11.2" />
 			<dependency id="Unity.Container" version="5.11.8" />
 			<dependency id="System.Reflection.Emit.Lightweight" version="4.6.0" />
+			<dependency id="System.Runtime.Serialization.Formatters" version="10.0.0" />
 		</group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Откорректирована поддержка BinaryFormatter для Net10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Tests**
  * Добавлен новый модульный тест для проверки функциональности двоичной сериализации.

* **Chores**
  * Обновлены версии NuGet-пакетов с 8.0.0-beta04 на 8.0.0-beta05.
  * Добавлена зависимость System.Runtime.Serialization.Formatters для целевой платформы .NET 10.0.
  * Обновлены связанные зависимости пакетов.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->