### PR TITLE
Added support of DateOnly at PostgresDataService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ DetailVariableDef.ViewGenerator = null; // or resolving of interface IViewGenera
 7. Dependency injection of `IConfigResolver` throught the property of `SQLDataService`.
 8. Support of Net10.
 9. Added stub classes for `IAuditService`, `IBusinessServerProvider` (`EmptyAuditService`, `EmptyBusinessServerProvider`).
+10. Support of type `DateOnly` for `PostgresDataService`.
 
 ### Changed
 1. Method `LockService.ClearAllUserLocks` changed to unstatic.

--- a/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
+++ b/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
@@ -594,6 +594,14 @@
                     return "timestamp'" + dt.ToString("yyyy-MM-dd HH:mm:ss.fff") + "'";
                 }
 
+#if NET6_0_OR_GREATER
+                if (value is DateOnly)
+                { // Поддержка типа DateOnly только с .NET 6.
+                    DateOnly d = (DateOnly)value;
+                    return "date '" + d.ToString("yyyy-MM-dd") + "'";
+                }
+#endif
+
                 Type valueType = value.GetType();
 
                 if (valueType.FullName == "Microsoft.OData.Edm.Library.Date" || valueType.FullName == "Microsoft.OData.Edm.Date")

--- a/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
+++ b/ICSSoft.STORMNET.Business.PostgresDataService/PostgresDataService.cs
@@ -598,7 +598,7 @@
                 if (value is DateOnly)
                 { // Поддержка типа DateOnly только с .NET 6.
                     DateOnly d = (DateOnly)value;
-                    return "date '" + d.ToString("yyyy-MM-dd") + "'";
+                    return "date '" + d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + "'";
                 }
 #endif
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Flexberry PLATFORM
+Copyright (c) 2026 Flexberry PLATFORM
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.MSSQLDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.MSSQLDataService</id>
-    <version>8.0.0-beta06</version>
+    <version>8.0.0-beta07</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,7 +18,7 @@
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta06`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta07`.
 		4. Version of `Microsoft.Data.SqlClient` changed to `6.1.3`.
 		5. Removed support of .NET Core 3.1.
 	</releaseNotes>
@@ -26,25 +26,25 @@
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
       </group>
 		<group targetFramework=".NETFramework4.6.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 		</group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 		  <dependency id="System.Data.SqlClient" version="4.9.0" />
       </group>
 		<group targetFramework="net6.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="System.Data.SqlClient" version="4.9.0" />
 		</group>
 		<group targetFramework="net7.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="System.Data.SqlClient" version="4.9.0" />
 		</group>
 		<group targetFramework="net10.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="Microsoft.Data.SqlClient" version="6.1.3" />
 		</group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.OracleDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.OracleDataService</id>
-    <version>8.0.0-beta06</version>
+    <version>8.0.0-beta07</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -18,34 +18,34 @@
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta06`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta07`.
 		4. Removed support of .NET Core 3.1.
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2025</copyright>
     <tags>Flexberry ORM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
         <dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
       </group>
 		<group targetFramework=".NETFramework4.6.1">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="Oracle.ManagedDataAccess" version="12.1.22" />
 		</group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
         <dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
       </group>
 		<group targetFramework="net6.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
 		<group targetFramework="net7.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
 		<group targetFramework="net10.0">
-			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			<dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.3" />
 		</group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.PostgresDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.PostgresDataService</id>
-    <version>8.0.0-beta06</version>
+    <version>8.0.0-beta07</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>
@@ -14,11 +14,12 @@
     <releaseNotes>
 		Added
 		1. Support of NET 10.
+		2. Support of type `DateOnly`.
 
 		Changed
 		1. Data services `MSSQLDataService`, `OracleDataService`, `PostgresDataService` need initialization of property `CurrentUser` if `value.FunctionDef.StringedView == "CurrentUser"`.
 		2. Constructor of class `SQLDataService` (`DRDataService`, `MSSQLDataService`, `OracleDataService`, `PostgresDataService`): added dependency injection of `IAuditService` and `ISecurityManager` throught the constructor of `SQLDataService`.
-		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta06`.
+		3. Version of `NewPlatform.Flexberry.ORM` changed to `8.0.0-beta07`.
 		4. Version of `Npgsql` changed to `4.0.17` for `.NETFramework4.5`, to `5.0.18` for `.NETStandard2.0` and upper, to `10.0.0` for `.NET10`.
 		5. Removed support of .NET Core 3.1.
 	</releaseNotes>
@@ -26,27 +27,27 @@
     <tags>Flexberry ORM</tags>
 	  <dependencies>
 		  <group targetFramework=".NETFramework4.5">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="4.0.17" />
 		  </group>
 		  <group targetFramework=".NETFramework4.6.1">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="4.0.17" />
 		  </group>
 		  <group targetFramework=".NETStandard2.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net6.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net7.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="5.0.18" />
 		  </group>
 		  <group targetFramework="net10.0">
-			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta06" />
+			  <dependency id="NewPlatform.Flexberry.ORM" version="8.0.0-beta07" />
 			  <dependency id="Npgsql" version="10.0.0" />
 		  </group>
 	  </dependencies>

--- a/NewPlatform.Flexberry.ORM.nuspec
+++ b/NewPlatform.Flexberry.ORM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM</id>
-    <version>8.0.0-beta06</version>
+    <version>8.0.0-beta07</version>
     <title>Flexberry ORM</title>
     <authors>New Platform Ltd</authors>
     <owners>New Platform Ltd</owners>


### PR DESCRIPTION
Для #282 .
- Добавлена поддержка DateOnly в PostgresDataService.
- Поднята версия до 8.0.0-beta07.
- Тест будет реализован отдельно.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **New Features**
  * Добавлена поддержка `DateOnly` для PostgreSQL Data Service (.NET 6 и выше).

* **Chores**
  * Обновлены версии пакетов до `8.0.0-beta07`.
  * Обновлена дата лицензии.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->