### PR TITLE
Добавлено событие "Изменения объектов сохранены"

### DIFF
--- a/ICSSoft.STORMNET.Business/Interfaces/INotifyUpdateObjects.cs
+++ b/ICSSoft.STORMNET.Business/Interfaces/INotifyUpdateObjects.cs
@@ -37,11 +37,26 @@
         void AfterSuccessUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects);
 
         /// <summary>
+        /// After commit update objects. Fires AFTER the transaction is committed.
+        /// </summary>
+        /// <param name="operationId">Unique operation Id.</param>
+        /// <param name="dataService">Data service.</param>
+        /// <param name="dataObjects">Data objects for update.</param>
+        void AfterCommitUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects);
+
+        /// <summary>
         /// After fail update objects.
         /// </summary>
         /// <param name="operationId">Unique operation Id.</param>
         /// <param name="dataService">Data service.</param>
         /// <param name="dataObjects">Data objects for update.</param>
         void AfterFailUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects);
+
+        /// <summary>
+        /// Remove all internal state captured for the specified operation.
+        /// Called on failure to prevent memory leaks.
+        /// </summary>
+        /// <param name="operationId">Unique operation Id.</param>
+        void CleanupStateStore(Guid operationId);
     }
 }

--- a/ICSSoft.STORMNET.Business/Notifiers/NotifierUpdateObjects.cs
+++ b/ICSSoft.STORMNET.Business/Notifiers/NotifierUpdateObjects.cs
@@ -382,6 +382,165 @@
                 if (dataObject is INotifyUpdateObject notifyUpdateObject)
                 {
                     Tuple<ObjectStatus, object, object> stateStoreValue = GetFromStateStore(operationId, dataObjectType, dataObject.__PrimaryKey, string.Empty);
+
+                    notifyUpdateObject.AfterSuccessUpdateObject(dataObject, stateStoreValue.Item1, dataObjects);
+                }
+
+                List<string> alteredPropertyNames = new List<string>(dataObject.GetAlteredPropertyNames());
+
+                if (subscribedPropNotifiers != null && (subscribedPropNotifiers.ContainsKey(dataObjectType) || status == ObjectStatus.Deleted))
+                {
+                    IEnumerable<string> subscribedPropertyNames = subscribedPropNotifiers[dataObjectType];
+                    if (subscribedPropertyNames != null)
+                    {
+                        foreach (string propertyName in subscribedPropertyNames)
+                        {
+                            object oldValue = null;
+                            object newValue = null;
+                            bool notify = false;
+                            if (status == ObjectStatus.Deleted)
+                            {
+                                oldValue = Information.GetPropValueByName(dataObject, propertyName);
+                                notify = true;
+                            }
+                            else if (status == ObjectStatus.Created)
+                            {
+                                newValue = Information.GetPropValueByName(dataObject, propertyName);
+                                notify = true;
+                            }
+                            else if (alteredPropertyNames.Contains(propertyName))
+                            {
+                                DataObject dataCopy = dataObject.GetDataCopy();
+                                if (dataCopy != null)
+                                {
+                                    oldValue = Information.GetPropValueByName(dataCopy, propertyName);
+                                }
+
+                                newValue = Information.GetPropValueByName(dataObject, propertyName);
+                                notify = true;
+                            }
+
+                            if (notify)
+                            {
+                                var stateStoreValue = new Tuple<ObjectStatus, object, object>(status, oldValue, newValue);
+
+                                NotifierUpdatePropertyByType.AfterSuccessUpdateProperty(dataObject, status, propertyName, oldValue, newValue);
+                            }
+                        }
+                    }
+                }
+
+                IDictionary<string, Tuple<ObjectStatus, object, object>> dataFromStore = null;
+
+                if (stateStore.ContainsKey(operationId))
+                {
+                    IDictionary<Type, IDictionary<object, IDictionary<string, Tuple<ObjectStatus, object, object>>>> typeDictionary = stateStore[operationId];
+
+                    if (typeDictionary.ContainsKey(dataObjectType))
+                    {
+                        IDictionary<object, IDictionary<string, Tuple<ObjectStatus, object, object>>> primaryKeyDictionary = typeDictionary[dataObjectType];
+
+                        if (primaryKeyDictionary.ContainsKey(dataObject.__PrimaryKey))
+                        {
+                            dataFromStore = primaryKeyDictionary[dataObject.__PrimaryKey];
+                        }
+                    }
+                }
+
+                if (dataFromStore != null)
+                {
+                    string[] keys = new string[dataFromStore.Count];
+                    dataFromStore.Keys.CopyTo(keys, 0);
+                    foreach (string propertyName in keys)
+                    {
+                        if (!string.IsNullOrWhiteSpace(propertyName))
+                        {
+                            Type propertyType = Information.GetPropertyType(dataObjectType, propertyName);
+
+                            if (typeof(INotifyUpdateProperty).IsAssignableFrom(propertyType))
+                            {
+                                Tuple<ObjectStatus, object, object> valuesFromStateStore = GetFromStateStore(operationId, dataObjectType, dataObject.__PrimaryKey, propertyName);
+                                if (valuesFromStateStore != null)
+                                {
+                                    ObjectStatus objectStatusFromStateStore = valuesFromStateStore.Item1;
+                                    INotifyUpdateProperty oldValue = valuesFromStateStore.Item2 as INotifyUpdateProperty;
+                                    INotifyUpdateProperty newValue = valuesFromStateStore.Item3 as INotifyUpdateProperty;
+
+                                    INotifyUpdateProperty notifyUpdateProperty = newValue ?? oldValue;
+
+                                    if (notifyUpdateProperty != null)
+                                    {
+                                        notifyUpdateProperty.AfterSuccessUpdateProperty(dataObject, objectStatusFromStateStore, propertyName, oldValue, newValue);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (status == ObjectStatus.Deleted)
+                {
+                    string[] allPropertyNames = Information.GetAllPropertyNames(dataObjectType);
+
+                    foreach (string propertyName in allPropertyNames)
+                    {
+                        if (propertyName == nameof(DataObject.IsReadOnly) || propertyName == nameof(DataObject.DynamicProperties) || propertyName == nameof(DataObject.__PrototypeKey) || propertyName == nameof(DataObject.Prototyped) || propertyName == nameof(DataObject.__PrimaryKey))
+                        {
+                            continue;
+                        }
+
+                        Type propertyType = Information.GetPropertyType(dataObjectType, propertyName);
+
+                        if (typeof(INotifyUpdateProperty).IsAssignableFrom(propertyType))
+                        {
+                            INotifyUpdateProperty oldValue = null;
+                            INotifyUpdateProperty newValue = null;
+
+                            var valuesFromStateStore = GetFromStateStore(operationId, dataObjectType, dataObject.__PrimaryKey, propertyName);
+
+                            if (valuesFromStateStore != null)
+                            {
+                                oldValue = valuesFromStateStore.Item2 as INotifyUpdateProperty;
+                                newValue = valuesFromStateStore.Item3 as INotifyUpdateProperty;
+                            }
+                            else
+                            {
+                                oldValue = Information.GetPropValueByName(dataObject, propertyName) as INotifyUpdateProperty;
+                            }
+
+                            INotifyUpdateProperty notifyUpdateProperty = oldValue;
+
+                            if (notifyUpdateProperty != null)
+                            {
+                                notifyUpdateProperty.AfterSuccessUpdateProperty(dataObject, status, propertyName, oldValue, newValue);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc cref="INotifyUpdateObjects"/>
+        public virtual void AfterCommitUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects)
+        {
+            if (dataObjects == null)
+            {
+                return;
+            }
+
+            if (!stateStore.ContainsKey(operationId))
+            {
+                return;
+            }
+
+            foreach (DataObject dataObject in dataObjects)
+            {
+                Type dataObjectType = dataObject.GetType();
+                ObjectStatus status = dataObject.GetStatus(false);
+
+                if (dataObject is INotifyUpdateObject notifyUpdateObject)
+                {
+                    Tuple<ObjectStatus, object, object> stateStoreValue = GetFromStateStore(operationId, dataObjectType, dataObject.__PrimaryKey, string.Empty);
                     RemoveFromStateStore(operationId, dataObjectType, dataObject.__PrimaryKey, string.Empty);
 
                     notifyUpdateObject.AfterSuccessUpdateObject(dataObject, stateStoreValue.Item1, dataObjects);
@@ -523,6 +682,17 @@
                     }
                 }
             }
+
+            stateStore.Remove(operationId);
+        }
+
+        /// <summary>
+        /// Remove all stateStore data for the specified operation.
+        /// </summary>
+        /// <param name="operationId">Operation id.</param>
+        public virtual void CleanupStateStore(Guid operationId)
+        {
+            stateStore.Remove(operationId);
         }
 
         /// <inheritdoc cref="INotifyUpdateObjects"/>

--- a/ICSSoft.STORMNET.Business/SQLDataService/DbTransactionWrapper.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/DbTransactionWrapper.cs
@@ -1,6 +1,7 @@
 ﻿namespace ICSSoft.STORMNET.Business
 {
     using System;
+    using System.Collections.Generic;
     using System.Data;
 
     /// <summary>
@@ -9,6 +10,11 @@
     public class DbTransactionWrapper : IDisposable
     {
         private IDbTransaction _transaction;
+
+        /// <summary>
+        /// Operation IDs pending post-commit notification via <see cref="INotifyUpdateObjects.AfterCommitUpdateObjects"/>.
+        /// </summary>
+        public List<Guid> PendingAfterCommitOperationIds { get; } = new List<Guid>();
 
         /// <summary>
         /// Initializes instance of <see cref="DbTransactionWrapper" />.

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.UpdateObjects.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.UpdateObjects.cs
@@ -39,14 +39,32 @@
 
             using (DbTransactionWrapper dbTransactionWrapper = new DbTransactionWrapper(this))
             {
+                DataObject[] allObjects = objects;
                 try
                 {
                     UpdateObjectsByExtConn(ref objects, DataObjectCache, AlwaysThrowException, dbTransactionWrapper);
                     dbTransactionWrapper.CommitTransaction();
+
+                    if (NotifierUpdateObjects != null)
+                    {
+                        foreach (Guid opId in dbTransactionWrapper.PendingAfterCommitOperationIds)
+                        {
+                            NotifierUpdateObjects.AfterCommitUpdateObjects(opId, this, allObjects);
+                        }
+                    }
                 }
                 catch (Exception)
                 {
                     dbTransactionWrapper.RollbackTransaction();
+
+                    if (NotifierUpdateObjects != null)
+                    {
+                        foreach (Guid opId in dbTransactionWrapper.PendingAfterCommitOperationIds)
+                        {
+                            NotifierUpdateObjects.CleanupStateStore(opId);
+                        }
+                    }
+
                     throw;
                 }
             }

--- a/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
+++ b/ICSSoft.STORMNET.Business/SQLDataService/SQLDataService.cs
@@ -5554,14 +5554,34 @@
                     foreach (DataObject dataObject in objects)
                     {
                         DataObject[] dObjs = new[] { dataObject };
-                        UpdateObjectsByExtConn(ref dObjs, dataObjectCache, alwaysThrowException, dbTransactionWrapper.Connection, dbTransactionWrapper.Transaction);
+                        UpdateObjectsByExtConn(ref dObjs, dataObjectCache, alwaysThrowException, dbTransactionWrapper);
                     }
 
                     dbTransactionWrapper.CommitTransaction();
+
+                    if (NotifierUpdateObjects != null)
+                    {
+                        for (int i = 0; i < dbTransactionWrapper.PendingAfterCommitOperationIds.Count; i++)
+                        {
+                            NotifierUpdateObjects.AfterCommitUpdateObjects(
+                                dbTransactionWrapper.PendingAfterCommitOperationIds[i],
+                                this,
+                                new[] { objects[i] });
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
                     dbTransactionWrapper.RollbackTransaction();
+
+                    if (NotifierUpdateObjects != null)
+                    {
+                        foreach (Guid opId in dbTransactionWrapper.PendingAfterCommitOperationIds)
+                        {
+                            NotifierUpdateObjects.CleanupStateStore(opId);
+                        }
+                    }
+
                     throw;
                 }
             }
@@ -5646,6 +5666,7 @@
                 {
                     operationUniqueId = Guid.NewGuid();
                     NotifierUpdateObjects.BeforeUpdateObjects(operationUniqueId.Value, this, dbTransactionWrapper.Transaction, objects);
+                    dbTransactionWrapper.PendingAfterCommitOperationIds.Add(operationUniqueId.Value);
                 }
 
                 if (AuditService.IsAuditEnabled)

--- a/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotifyUpdateTest.cs
+++ b/NewPlatform.Flexberry.ORM.IntegratedTests/ICSSoft.STORMNET.Business/NotifyUpdateTest.cs
@@ -109,6 +109,47 @@
         }
 
         /// <summary>
+        /// Test for <see cref="INotifyUpdateObjects.AfterCommitUpdateObjects"/> with <see cref="SQLDataService.UpdateObjectsOrdered"/>.
+        /// </summary>
+        [Fact]
+        public void AfterCommitUpdateObjectsOrderedTest()
+        {
+            foreach (IDataService dataService in DataServices)
+            {
+                // Arrange.
+                var ds = (SQLDataService)dataService;
+                ds.NotifierUpdateObjects = new NotifyUpdateObjectsGeneratedMock();
+
+                // Act.
+                var bear = new Медведь() { ПорядковыйНомер = 7 };
+                var dataObjectForTest = new DataObjectForTest() { Name = "OrderedDOT" };
+                DataObject[] dataObjects = new DataObject[] { bear, dataObjectForTest };
+                ds.UpdateObjectsOrdered(ref dataObjects);
+
+                // Assert: both objects received AfterCommitUpdateObjects.
+                var bearFootprint = bear.DynamicProperties[nameof(INotifyUpdateObjects.AfterCommitUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
+                Assert.NotNull(bearFootprint);
+                Assert.Equal(ds, bearFootprint.Item2);
+                Assert.Equal(bear, bearFootprint.Item3.First());
+                bear.DynamicProperties.Remove(nameof(INotifyUpdateObjects.AfterCommitUpdateObjects));
+
+                var dotFootprint = dataObjectForTest.DynamicProperties[nameof(INotifyUpdateObjects.AfterCommitUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
+                Assert.NotNull(dotFootprint);
+                Assert.Equal(ds, dotFootprint.Item2);
+                Assert.Equal(dataObjectForTest, dotFootprint.Item3.First());
+
+                // Verify BeforeUpdateObjects and AfterCommitUpdateObjects share the same operationId per object.
+                var bearBeforeFootprint = bear.DynamicProperties[nameof(INotifyUpdateObjects.BeforeUpdateObjects)] as Tuple<Guid, IDataService, System.Data.IDbTransaction, IEnumerable<DataObject>>;
+                Assert.Equal(bearBeforeFootprint.Item1, bearFootprint.Item1);
+
+                // Clean up.
+                bear.DynamicProperties.Remove(nameof(INotifyUpdateObjects.BeforeUpdateObjects));
+                dataObjectForTest.DynamicProperties.Remove(nameof(INotifyUpdateObjects.AfterCommitUpdateObjects));
+                dataObjectForTest.DynamicProperties.Remove(nameof(INotifyUpdateObjects.BeforeUpdateObjects));
+            }
+        }
+
+        /// <summary>
         /// Test for <see cref="INotifyUpdateObject"/> intarface.
         /// </summary>
         [Fact]
@@ -340,11 +381,18 @@
             Assert.Equal(dataObject, afterSuccessUpdateObjectsFootprint.Item3.First());
             dataObject.DynamicProperties.Remove(nameof(INotifyUpdateObjects.AfterSuccessUpdateObjects));
 
+            var afterCommitUpdateObjectsFootprint = dataObject.DynamicProperties[nameof(INotifyUpdateObjects.AfterCommitUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
+            Assert.NotNull(afterCommitUpdateObjectsFootprint);
+            Assert.Equal(dataService, afterCommitUpdateObjectsFootprint.Item2);
+            Assert.Equal(dataObject, afterCommitUpdateObjectsFootprint.Item3.First());
+            dataObject.DynamicProperties.Remove(nameof(INotifyUpdateObjects.AfterCommitUpdateObjects));
+
             var afterFailUpdateObjectsFootprint = dataObject.DynamicProperties[nameof(INotifyUpdateObjects.AfterFailUpdateObjects)] as Tuple<Guid, IDataService, System.Data.IDbTransaction, IEnumerable<DataObject>>;
             Assert.Null(afterFailUpdateObjectsFootprint);
 
             Assert.Equal(beforeUpdateObjectsFootprint.Item1, afterSuccessSqlUpdateObjectsFootprint.Item1);
             Assert.Equal(afterSuccessUpdateObjectsFootprint.Item1, afterSuccessSqlUpdateObjectsFootprint.Item1);
+            Assert.Equal(afterCommitUpdateObjectsFootprint.Item1, afterSuccessSqlUpdateObjectsFootprint.Item1);
         }
 
         /// <summary>
@@ -365,6 +413,9 @@
 
             var failedAfterSuccessUpdateObjectsFootprint = dataObject.DynamicProperties[nameof(INotifyUpdateObjects.AfterSuccessUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
             Assert.Null(failedAfterSuccessUpdateObjectsFootprint);
+
+            var failedAfterCommitUpdateObjectsFootprint = dataObject.DynamicProperties[nameof(INotifyUpdateObjects.AfterCommitUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
+            Assert.Null(failedAfterCommitUpdateObjectsFootprint);
 
             var failedAfterFailUpdateObjectsFootprint = dataObject.DynamicProperties[nameof(INotifyUpdateObjects.AfterFailUpdateObjects)] as Tuple<Guid, IDataService, IEnumerable<DataObject>>;
             Assert.NotNull(failedAfterFailUpdateObjectsFootprint);

--- a/NewPlatform.Flexberry.ORM.Test.Objects/FileForTests.cs
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/FileForTests.cs
@@ -41,25 +41,25 @@ namespace NewPlatform.Flexberry.ORM.Tests
         /// <inheritdoc cref="INotifyUpdateProperty"/>
         public void BeforeUpdateProperty(DataObject dataObject, ObjectStatus status, string propertyName, object oldValue, object newValue)
         {
-            dataObject.DynamicProperties.Add(nameof(BeforeUpdateProperty), new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue));
+            dataObject.DynamicProperties[nameof(BeforeUpdateProperty)] = new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue);
         }
 
         /// <inheritdoc cref="INotifyUpdateProperty"/>
         public void AfterSuccessSqlUpdateProperty(DataObject dataObject, ObjectStatus status, string propertyName, object oldValue, object newValue)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterSuccessSqlUpdateProperty), new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue));
+            dataObject.DynamicProperties[nameof(AfterSuccessSqlUpdateProperty)] = new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue);
         }
 
         /// <inheritdoc cref="INotifyUpdateProperty"/>
         public void AfterSuccessUpdateProperty(DataObject dataObject, ObjectStatus status, string propertyName, object oldValue, object newValue)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterSuccessUpdateProperty), new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue));
+            dataObject.DynamicProperties[nameof(AfterSuccessUpdateProperty)] = new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue);
         }
 
         /// <inheritdoc cref="INotifyUpdateProperty"/>
         public void AfterFailUpdateProperty(DataObject dataObject, ObjectStatus status, string propertyName, object oldValue, object newValue)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterFailUpdateProperty), new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue));
+            dataObject.DynamicProperties[nameof(AfterFailUpdateProperty)] = new Tuple<ObjectStatus, string, object, object>(status, propertyName, oldValue, newValue);
         }
 
         /// <inheritdoc cref="IComparableType"/>

--- a/NewPlatform.Flexberry.ORM.Test.Objects/Homer.cs
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/Homer.cs
@@ -38,25 +38,25 @@ namespace NewPlatform.Flexberry.ORM.Tests
         /// <inheritdoc cref="INotifyUpdateObject"/>
         public void BeforeUpdateObject(DataObject dataObject, ObjectStatus status, IEnumerable<DataObject> dataObjects)
         {
-            dataObject.DynamicProperties.Add(nameof(BeforeUpdateObject), new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects));
+            dataObject.DynamicProperties[nameof(BeforeUpdateObject)] = new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects);
         }
 
         /// <inheritdoc cref="INotifyUpdateObject"/>
         public void AfterSuccessSqlUpdateObject(DataObject dataObject, ObjectStatus status, IEnumerable<DataObject> dataObjects)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterSuccessSqlUpdateObject), new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects));
+            dataObject.DynamicProperties[nameof(AfterSuccessSqlUpdateObject)] = new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects);
         }
 
         /// <inheritdoc cref="INotifyUpdateObject"/>
         public void AfterSuccessUpdateObject(DataObject dataObject, ObjectStatus status, IEnumerable<DataObject> dataObjects)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterSuccessUpdateObject), new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects));
+            dataObject.DynamicProperties[nameof(AfterSuccessUpdateObject)] = new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects);
         }
 
         /// <inheritdoc cref="INotifyUpdateObject"/>
         public void AfterFailUpdateObject(DataObject dataObject, ObjectStatus status, IEnumerable<DataObject> dataObjects)
         {
-            dataObject.DynamicProperties.Add(nameof(AfterFailUpdateObject), new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects));
+            dataObject.DynamicProperties[nameof(AfterFailUpdateObject)] = new Tuple<ObjectStatus, IEnumerable<DataObject>>(status, dataObjects);
         }
 
         // *** End programmer edit section *** (Homer CustomMembers)

--- a/NewPlatform.Flexberry.ORM.Test.Objects/NotifyUpdateObjectsGeneratedMock.cs
+++ b/NewPlatform.Flexberry.ORM.Test.Objects/NotifyUpdateObjectsGeneratedMock.cs
@@ -57,6 +57,14 @@ namespace NewPlatform.Flexberry.ORM.Tests
             dataObject.DynamicProperties.Add(nameof(AfterSuccessUpdateObjects), new Tuple<Guid, IDataService, IEnumerable<DataObject>>(operationId, dataService, dataObjects));
         }
 
+        /// <inheritdoc cref="INotifyUpdateObjects"/>
+        public void AfterCommitUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects)
+        {
+            var dataObject = dataObjects.First();
+
+            dataObject.DynamicProperties.Add(nameof(AfterCommitUpdateObjects), new Tuple<Guid, IDataService, IEnumerable<DataObject>>(operationId, dataService, dataObjects));
+        }
+
 
         /// <inheritdoc cref="INotifyUpdateObjects"/>
         public void AfterFailUpdateObjects(Guid operationId, IDataService dataService, IEnumerable<DataObject> dataObjects)
@@ -64,6 +72,11 @@ namespace NewPlatform.Flexberry.ORM.Tests
             var dataObject = dataObjects.First();
 
             dataObject.DynamicProperties.Add(nameof(AfterFailUpdateObjects), new Tuple<Guid, IDataService, IEnumerable<DataObject>>(operationId, dataService, dataObjects));
+        }
+
+        /// <inheritdoc cref="INotifyUpdateObjects"/>
+        public void CleanupStateStore(Guid operationId)
+        {
         }
 
         // *** End programmer edit section *** (NotifyUpdateObjectsGeneratedMock CustomMembers)


### PR DESCRIPTION
### Как использовать новое событие AfterCommitUpdateObjects
Подписка — как на обычный .NET event:
```cs
var ds = (SQLDataService)dataService;
ds.AfterCommitUpdateObjects += (sender, e) =>
{
    foreach (DataObject obj in e.DataObjects)
    {
        var status = obj.GetStatus(false);
        
        if (status == ObjectStatus.Created)
        {
            // объект добавлен в БД и транзакция закоммичена
        }
        else if (status == ObjectStatus.Altered)
        {
            // объект изменён в БД и транзакция закоммичена
        }
    }
};
```

#### Ключевые моменты
- Гарантированно срабатывает после CommitTransaction() — данные уже в БД.
- При ошибке SQL или откате транзакции — не срабатывает.
- Передаёт массив объектов со статусами Created/Altered (UnAltered, если были в исходном массиве). Удалённые объекты исключены (аналогично AfterSuccessUpdateObjects).
- Если вызывается UpdateObjectsByExtConn напрямую (самостоятельное управление транзакцией) — событие нужно вызывать вручную после коммита.